### PR TITLE
[C++] Expose ordered field in CategoryColumn

### DIFF
--- a/cpp/src/feather/reader.cc
+++ b/cpp/src/feather/reader.cc
@@ -146,7 +146,8 @@ Status TableReader::GetCategory(std::shared_ptr<metadata::Column> col_meta,
 
   auto levels_meta = cat_meta->levels();
   RETURN_NOT_OK(GetPrimitiveArray(levels_meta, &levels));
-  *out = std::make_shared<CategoryColumn>(col_meta, values, levels);
+  *out = std::make_shared<CategoryColumn>(col_meta, values, levels,
+    cat_meta->ordered());
 
   return Status::OK();
 }

--- a/cpp/src/feather/reader.h
+++ b/cpp/src/feather/reader.h
@@ -60,9 +60,11 @@ class CategoryColumn : public Column {
  public:
   CategoryColumn(const std::shared_ptr<metadata::Column>& metadata,
       const PrimitiveArray& values,
-      const PrimitiveArray& levels) :
+      const PrimitiveArray& levels,
+      bool ordered = false) :
       Column(ColumnType::CATEGORY, metadata, values),
-      levels_(levels) {
+      levels_(levels),
+      ordered_(ordered) {
     category_meta_ = static_cast<const metadata::CategoryColumn*>(metadata.get());
   }
 
@@ -70,9 +72,14 @@ class CategoryColumn : public Column {
     return levels_;
   }
 
+  bool ordered() const {
+    return ordered_;
+  }
+
  private:
   const metadata::CategoryColumn* category_meta_;
   PrimitiveArray levels_;
+  bool ordered_;
 };
 
 class TimestampColumn : public Column {

--- a/cpp/src/feather/writer-test.cc
+++ b/cpp/src/feather/writer-test.cc
@@ -162,6 +162,7 @@ TEST_F(TestTableWriter, CategoryRoundtrip) {
 
   auto cat_col = static_cast<const CategoryColumn*>(col.get());
   ASSERT_TRUE(cat_col->levels().Equals(levels));
+  ASSERT_TRUE(cat_col->ordered());
 }
 
 TEST_F(TestTableWriter, TimestampRoundtrip) {


### PR DESCRIPTION
I don't understand why you cache the levels as well as the metadata object, but I followed the same pattern for the `ordered` flag.
