### PR TITLE
[C++] Remove old reference to `update_fbs.sh`

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -13,9 +13,6 @@ run:
 # Sets the thirdparty build environment variables
 source develop_env.sh
 
-# Generates the flatbuffers bindings, to be automated
-./update_fbs.sh
-
 mkdir release-build
 cd release-build
 export FEATHER_HOME=$HOME/local


### PR DESCRIPTION
Since `7dad4e93` the code generation is done automatically as a part of the build.