### PR TITLE
[C++] const safety

### DIFF
--- a/cpp/src/feather/metadata.cc
+++ b/cpp/src/feather/metadata.cc
@@ -407,7 +407,7 @@ size_t Table::num_columns() const {
   return table->columns()->size();
 }
 
-std::shared_ptr<Column> Table::GetColumn(size_t i) {
+std::shared_ptr<Column> Table::GetColumn(size_t i) const {
   const fbs::CTable* table = static_cast<const fbs::CTable*>(table_);
   const fbs::Column* col = table->columns()->Get(i);
 
@@ -430,7 +430,7 @@ std::shared_ptr<Column> Table::GetColumn(size_t i) {
   return std::shared_ptr<Column>(nullptr);
 }
 
-std::shared_ptr<Column> Table::GetColumnNamed(const std::string& name) {
+std::shared_ptr<Column> Table::GetColumnNamed(const std::string& name) const {
   // Not yet implemented
   return std::shared_ptr<Column>(nullptr);
 }

--- a/cpp/src/feather/metadata.h
+++ b/cpp/src/feather/metadata.h
@@ -162,8 +162,8 @@ class Table {
   int64_t num_rows() const;
 
   size_t num_columns() const;
-  std::shared_ptr<Column> GetColumn(size_t i);
-  std::shared_ptr<Column> GetColumnNamed(const std::string& name);
+  std::shared_ptr<Column> GetColumn(size_t i) const;
+  std::shared_ptr<Column> GetColumnNamed(const std::string& name) const;
 
  private:
   std::shared_ptr<Buffer> buffer_;

--- a/cpp/src/feather/reader.cc
+++ b/cpp/src/feather/reader.cc
@@ -90,7 +90,7 @@ int64_t TableReader::num_columns() const {
   return metadata_.num_columns();
 }
 
-Status TableReader::GetPrimitiveArray(const ArrayMetadata& meta, PrimitiveArray* out) {
+Status TableReader::GetPrimitiveArray(const ArrayMetadata& meta, PrimitiveArray* out) const {
   // Buffer data from the source (may or may not perform a copy depending on
   // input source)
   std::shared_ptr<Buffer> buffer;
@@ -128,7 +128,7 @@ Status TableReader::GetPrimitiveArray(const ArrayMetadata& meta, PrimitiveArray*
 }
 
 Status TableReader::GetPrimitive(std::shared_ptr<metadata::Column> col_meta,
-    std::shared_ptr<Column>* out) {
+    std::shared_ptr<Column>* out) const {
   auto values_meta = col_meta->values();
   PrimitiveArray values;
   RETURN_NOT_OK(GetPrimitiveArray(values_meta, &values));
@@ -137,7 +137,7 @@ Status TableReader::GetPrimitive(std::shared_ptr<metadata::Column> col_meta,
 }
 
 Status TableReader::GetCategory(std::shared_ptr<metadata::Column> col_meta,
-    std::shared_ptr<Column>* out) {
+    std::shared_ptr<Column>* out) const {
   PrimitiveArray values, levels;
   auto cat_meta = static_cast<metadata::CategoryColumn*>(col_meta.get());
 
@@ -153,7 +153,7 @@ Status TableReader::GetCategory(std::shared_ptr<metadata::Column> col_meta,
 }
 
 Status TableReader::GetTimestamp(std::shared_ptr<metadata::Column> col_meta,
-    std::shared_ptr<Column>* out) {
+    std::shared_ptr<Column>* out) const {
   PrimitiveArray values;
   auto ts_meta = static_cast<metadata::TimestampColumn*>(col_meta.get());
 
@@ -164,7 +164,7 @@ Status TableReader::GetTimestamp(std::shared_ptr<metadata::Column> col_meta,
 }
 
 Status TableReader::GetTime(std::shared_ptr<metadata::Column> col_meta,
-    std::shared_ptr<Column>* out) {
+    std::shared_ptr<Column>* out) const {
   PrimitiveArray values;
   auto time_meta = static_cast<metadata::TimeColumn*>(col_meta.get());
 
@@ -174,7 +174,7 @@ Status TableReader::GetTime(std::shared_ptr<metadata::Column> col_meta,
   return Status::OK();
 }
 
-Status TableReader::GetColumn(int i, std::shared_ptr<Column>* out) {
+Status TableReader::GetColumn(int i, std::shared_ptr<Column>* out) const {
   std::shared_ptr<metadata::Column> col_meta = metadata_.GetColumn(i);
   switch (col_meta->type()) {
     case ColumnType::PRIMITIVE:

--- a/cpp/src/feather/reader.h
+++ b/cpp/src/feather/reader.h
@@ -148,28 +148,28 @@ class TableReader {
   int64_t num_rows() const;
   int64_t num_columns() const;
 
-  Status GetColumn(int i, std::shared_ptr<Column>* out);
+  Status GetColumn(int i, std::shared_ptr<Column>* out) const;
 
  private:
   Status GetPrimitive(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out);
+      std::shared_ptr<Column>* out) const;
   Status GetCategory(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out);
+      std::shared_ptr<Column>* out) const;
 
   Status GetTimestamp(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out);
+      std::shared_ptr<Column>* out) const;
 
   Status GetTime(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out);
+      std::shared_ptr<Column>* out) const;
 
   Status GetDate(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out);
+      std::shared_ptr<Column>* out) const;
 
   // Retrieve a primitive array from the data source
   //
   // @returns: a Buffer instance, the precise type will depend on the kind of
   // input data source (which may or may not have memory-map like semantics)
-  Status GetPrimitiveArray(const ArrayMetadata& meta, PrimitiveArray* out);
+  Status GetPrimitiveArray(const ArrayMetadata& meta, PrimitiveArray* out) const;
 
   std::shared_ptr<RandomAccessReader> source_;
   metadata::Table metadata_;


### PR DESCRIPTION
Should be able to pass a reader as `const`.

Part of #63.