### PR TITLE
[R] Avoid cp -u

### DIFF
--- a/R/configure
+++ b/R/configure
@@ -1,7 +1,7 @@
 if [ -d "../cpp/src/feather" ]; then
   mkdir -p src/feather
-  cp -upv src/feather/*.h src/feather/*.cc ../cpp/src/feather/ || true
-  cp -upv ../cpp/src/feather/*.h ../cpp/src/feather/*.cc src/feather/
+  rsync -urv src/feather/ ../cpp/src/feather/ --include="*.cc" --include="*.h" || true
+  cp -pv ../cpp/src/feather/*.h ../cpp/src/feather/*.cc src/feather/
 fi
 
 if [ -d "../cpp/src/flatbuffers" ]; then


### PR DESCRIPTION
- R -> C++ uses `rsync`, failure doesn't matter
- C++ -> R doesn't use `-u`

In response to https://github.com/wesm/feather/pull/77#issuecomment-204544245. See http://superuser.com/questions/515373/cp-u-is-illegal-on-mac-what-are-the-alternatives for justification.