### PR TITLE
[Python] Add automated Python builds on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,42 @@ matrix:
     after_success:
     - Rscript -e 'install.packages("covr"); covr::codecov()'
     env: TRAVIS_LANG=R
+  - os: linux
+    language: python
+    python: 2.7
+    compiler: gcc
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install cython
+    - pip install -r requirements.txt
+    script: python setup.py test
+    env: TRAVIS_LANG=python
+  - os: linux
+    language: python
+    python: 3.4
+    compiler: gcc
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install cython
+    - pip install -r requirements.txt
+    script: python setup.py test
+    env: TRAVIS_LANG=python
+  - os: linux
+    language: python
+    python: 3.5
+    compiler: gcc
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install cython
+    - pip install -r requirements.txt
+    script: python setup.py test
+    env: TRAVIS_LANG=python
 
 before_install:
 - export FEATHER_CPP=$TRAVIS_BUILD_DIR/cpp


### PR DESCRIPTION
There's a bit of repetition on the .travis.yml due to not being able to just use a list of Python versions directly, unfortunately. Related to travis-ci/travis-ci#1519, I believe.

Most projects apparently solve this this by setting environment variables describing each build and some scripts to automatically install different compilers/virtualenvs as needed, but I decided to go for the simpler approach for now. If anyone wants to see the alternatives I've tried, [here's a link to the build history is travis](https://travis-ci.org/andrioni/feather/builds).