### PR TITLE
[Python] Fix compilation failure on 32-bit platforms

### DIFF
--- a/python/feather/interop.h
+++ b/python/feather/interop.h
@@ -527,7 +527,7 @@ class FeatherDeserializer {
   ConvertValues() {
     typedef typename feather_traits<T2>::T T;
 
-    npy_intp dims[1] = {arr_->length};
+    npy_intp dims[1] = {static_cast<npy_intp>(arr_->length)};
     out_ = PyArray_SimpleNew(1, dims, feather_traits<T2>::npy_type);
 
     if (out_ == NULL) {
@@ -553,7 +553,7 @@ class FeatherDeserializer {
   ConvertValues() {
     typedef typename feather_traits<T2>::T T;
 
-    npy_intp dims[1] = {arr_->length};
+    npy_intp dims[1] = {static_cast<npy_intp>(arr_->length)};
     if (arr_->null_count > 0) {
       out_ = PyArray_SimpleNew(1, dims, NPY_FLOAT64);
       if (out_ == NULL)  return;
@@ -575,7 +575,7 @@ class FeatherDeserializer {
   template <int T2>
   inline typename std::enable_if<feather_traits<T2>::is_boolean, void>::type
   ConvertValues() {
-    npy_intp dims[1] = {arr_->length};
+    npy_intp dims[1] = {static_cast<npy_intp>(arr_->length)};
     if (arr_->null_count > 0) {
       out_ = PyArray_SimpleNew(1, dims, NPY_OBJECT);
       if (out_ == NULL)  return;
@@ -609,7 +609,7 @@ class FeatherDeserializer {
   template <int T2>
   inline typename std::enable_if<T2 == PrimitiveType::UTF8, void>::type
   ConvertValues() {
-    npy_intp dims[1] = {arr_->length};
+    npy_intp dims[1] = {static_cast<npy_intp>(arr_->length)};
     out_ = PyArray_SimpleNew(1, dims, NPY_OBJECT);
     if (out_ == NULL)  return;
     PyObject** out_values = reinterpret_cast<PyObject**>(PyArray_DATA(out_));


### PR DESCRIPTION
Closes #91. 32-bit arch may needs some more specific attention at some point. 

There is a separate issue, which is distutils on Apple's default Python 2.7 compiling C extensions in 32-bit mode. On my OSX 10.0 (64-bit) machine, a 2014 Macbook Pro Core i7, I see

```shell
$ arch
i386
```

Building feather with `/usr/bin/python setup.py build` invokes `gcc -arch i386` which is incorrect. I googled a bit but didn't find a conclusive explanation how to fix it, so if someone figures it out, let me know. Something something universal binaries.