### PR TITLE
[C++] Implement a C99 API for libfeather

### DIFF
--- a/R/src/feather-read.cpp
+++ b/R/src/feather-read.cpp
@@ -15,9 +15,8 @@ std::unique_ptr<TableReader> openFeatherTable(const std::string& path) {
   return table;
 }
 
-std::shared_ptr<Column> getColumn(const TableReader& table, int i) {
-  std::shared_ptr<Column> col;
-
+std::unique_ptr<Column> getColumn(const TableReader& table, int i) {
+  std::unique_ptr<Column> col;
   stopOnFailure(table.GetColumn(i, &col));
   return col;
 }

--- a/R/src/feather-types.cpp
+++ b/R/src/feather-types.cpp
@@ -200,7 +200,7 @@ SEXP rescaleFromInt64(const PrimitiveArray* pArray, double scale = 1) {
   return out;
 }
 
-SEXP toSEXP(ColumnPtr x) {
+SEXP toSEXP(const ColumnPtr& x) {
   ColumnMetadataPtr meta = x->metadata();
   const PrimitiveArray* val(&x->values());
 
@@ -210,7 +210,7 @@ SEXP toSEXP(ColumnPtr x) {
   case feather::ColumnType::CATEGORY: {
     IntegerVector out = toSEXP(val);
 
-    auto x_cat = std::static_pointer_cast<feather::CategoryColumn>(x);
+    auto x_cat = static_cast<feather::CategoryColumn*>(x.get());
     const PrimitiveArray* levels(&x_cat->levels());
 
     out.attr("levels") = Rf_coerceVector(toSEXP(levels), STRSXP);
@@ -223,14 +223,14 @@ SEXP toSEXP(ColumnPtr x) {
     return out;
   }
   case feather::ColumnType::TIME: {
-    auto x_time = std::static_pointer_cast<feather::TimeColumn>(x);
+    auto x_time = static_cast<feather::TimeColumn*>(x.get());
 
     DoubleVector out = rescaleFromInt64(val, timeScale(x_time->unit()));
     out.attr("class") = "time";
     return out;
   }
   case feather::ColumnType::TIMESTAMP: {
-    auto x_time = std::static_pointer_cast<feather::TimestampColumn>(x);
+    auto x_time = static_cast<feather::TimestampColumn*>(x.get());
 
     DoubleVector out = rescaleFromInt64(val, timeScale(x_time->unit()));
     out.attr("class") = CharacterVector::create("POSIXct", "POSIXt");

--- a/R/src/feather-types.cpp
+++ b/R/src/feather-types.cpp
@@ -27,7 +27,7 @@ RColType toRColType(FeatherColType x) {
   }
 };
 
-RColType toRColType(ColumnPtr x) {
+RColType toRColType(const ColumnPtr& x) {
   switch(x->type()) {
   case feather::ColumnType::PRIMITIVE:
     return toRColType(x->metadata()->values().type);

--- a/R/src/feather-types.h
+++ b/R/src/feather-types.h
@@ -21,4 +21,4 @@ RColType toRColType(FeatherColType x);
 RColType toRColType(const ColumnPtr& x);
 
 std::string toString(RColType x);
-SEXP toSEXP(ColumnPtr x);
+SEXP toSEXP(const ColumnPtr& x);

--- a/R/src/feather-types.h
+++ b/R/src/feather-types.h
@@ -2,7 +2,7 @@
 #include "feather/api.h"
 
 typedef feather::PrimitiveType::type FeatherColType;
-typedef std::shared_ptr<feather::Column> ColumnPtr;
+typedef std::unique_ptr<feather::Column> ColumnPtr;
 typedef std::shared_ptr<feather::metadata::Column> ColumnMetadataPtr;
 
 enum RColType {
@@ -18,7 +18,7 @@ enum RColType {
 };
 
 RColType toRColType(FeatherColType x);
-RColType toRColType(ColumnPtr x);
+RColType toRColType(const ColumnPtr& x);
 
 std::string toString(RColType x);
 SEXP toSEXP(ColumnPtr x);

--- a/cpp/src/feather/CMakeLists.txt
+++ b/cpp/src/feather/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 set(LIBFEATHER_SRCS
   buffer.cc
+  feather-c.cc
   io.cc
   metadata.cc
   reader.cc
@@ -59,6 +60,7 @@ else()
   )
 endif()
 
+ADD_FEATHER_TEST(tests/c-api-test)
 ADD_FEATHER_TEST(tests/io-test)
 ADD_FEATHER_TEST(tests/metadata-test)
 ADD_FEATHER_TEST(tests/writer-test)
@@ -88,6 +90,7 @@ install(FILES
   api.h
   buffer.h
   common.h
+  feather-c.h
   io.h
   metadata.h
   reader.h

--- a/cpp/src/feather/feather-c.cc
+++ b/cpp/src/feather/feather-c.cc
@@ -14,12 +14,51 @@
  * limitations under the License.
  */
 
+#include <cstdlib>
+#include <cstdint>
+
 #include "feather/reader.h"
 #include "feather/types.h"
 #include "feather/writer.h"
 #include "feather/feather-c.h"
 
 using namespace feather;
+
+static PrimitiveType::type FromCFeatherType(feather_type ctype) {
+  return static_cast<PrimitiveType::type>(static_cast<int>(ctype));
+}
+
+static feather_type ToCFeatherType(PrimitiveType::type type) {
+  return static_cast<feather_type>(static_cast<int>(type));
+}
+
+static feather_column_type ToCFeatherColumnType(ColumnType::type type) {
+  return static_cast<feather_column_type>(static_cast<int>(type));
+}
+
+static Status ToCFeatherArray(const PrimitiveArray& values, feather_array_t* out) {
+  out->type = ToCFeatherType(values.type);
+  out->length = values.length;
+  out->null_count = values.null_count;
+
+  out->nulls = values.nulls;
+  out->values = values.values;
+  out->offsets = values.offsets;
+
+  return Status::OK();
+}
+
+static Status FromCFeatherArray(feather_array_t* carr, PrimitiveArray* out) {
+  out->type = FromCFeatherType(carr->type);
+  out->length = carr->length;
+  out->null_count = carr->null_count;
+
+  out->nulls = carr->nulls;
+  out->values = carr->values;
+  out->offsets = carr->offsets;
+
+  return Status::OK();
+}
 
 #ifdef __cplusplus
 extern "C" {
@@ -28,8 +67,22 @@ extern "C" {
 #endif
 #endif
 
-static feather_status get_feather_status (const Status& s) {
-
+static feather_status get_feather_status(const Status& s) {
+  if (s.ok()) {
+    return FEATHER_OK;
+  } else if (s.IsOutOfMemory()) {
+    return FEATHER_OOM;
+  } else if (s.IsKeyError()) {
+    return FEATHER_KEY_ERROR;
+  } else if (s.IsInvalid()) {
+    return FEATHER_INVALID;
+  } else if (s.IsIOError()) {
+    return FEATHER_IO_ERROR;
+  } else if (s.IsNotImplemented()) {
+    return FEATHER_NOT_IMPLEMENTED;
+  } else {
+    return FEATHER_UNKNOWN;
+  }
 }
 
 #define FEATHER_CHECK_STATUS(s) do {                \
@@ -37,20 +90,110 @@ static feather_status get_feather_status (const Status& s) {
     if (!_s.ok()) return get_feather_status(_s);    \
   } while (0);
 
-#define FEATHER_CHECK_STATUS(s)
+#define FEATHER_CHECK_MALLOC(ptr) do {          \
+    if ((ptr) == nullptr) {                     \
+      return FEATHER_OOM;                       \
+    }                                           \
+  } while (0);
+
+/* Writer C API */
 
 feather_status
-feather_reader_open_file(const char* path, feather_reader_t** out) {
+feather_writer_open_file(const char* path, feather_writer_t** out) {
+  std::unique_ptr<TableWriter> writer;
   try {
     std::string str_path(path);
-    std::unique_ptr<TableReader> reader;
-
-    TableReader::OpenFile(path, &reader);
-
-    *out = reinterpret_cast<feather_reader_t*>(
+    FEATHER_CHECK_STATUS(TableWriter::OpenFile(str_path, &writer));
   } catch (const std::exception& e) {
     return FEATHER_OOM;
   }
+  *out = reinterpret_cast<feather_writer_t*>(writer.release());
+  return FEATHER_OK;
+}
+
+void feather_writer_set_num_rows(feather_writer_t* self, int64_t num_rows) {
+  reinterpret_cast<TableWriter*>(self)->SetNumRows(num_rows);
+}
+
+feather_status
+feather_writer_append_plain(feather_writer_t* self, const char* name,
+    feather_array_t* values) {
+  TableWriter* writer = reinterpret_cast<TableWriter*>(self);
+  PrimitiveArray cpp_values;
+
+  FEATHER_CHECK_STATUS(FromCFeatherArray(values, &cpp_values));
+
+  try {
+    std::string cpp_name(name);
+    return get_feather_status(writer->AppendPlain(cpp_name, cpp_values));
+  } catch (const std::exception& e) {
+    return FEATHER_OOM;
+  }
+}
+
+feather_status
+feather_writer_close(feather_writer_t* self) {
+  return get_feather_status(
+      reinterpret_cast<TableWriter*>(self)->Finalize());
+}
+
+feather_status
+feather_writer_free(feather_writer_t* self) {
+  delete reinterpret_cast<TableWriter*>(self);
+  return FEATHER_OK;
+}
+
+/* Reader C API */
+
+feather_status
+feather_column_free(feather_column_t* self) {
+  delete reinterpret_cast<Column*>(self->data);
+  return FEATHER_OK;
+}
+
+feather_status
+feather_reader_open_file(const char* path, feather_reader_t** out) {
+  std::unique_ptr<TableReader> reader;
+  try {
+    std::string str_path(path);
+    FEATHER_CHECK_STATUS(TableReader::OpenFile(str_path, &reader));
+  } catch (const std::exception& e) {
+    return FEATHER_OOM;
+  }
+  *out = reinterpret_cast<feather_reader_t*>(reader.release());
+  return FEATHER_OK;
+}
+
+int64_t
+feather_reader_num_rows(feather_reader_t* self) {
+  return reinterpret_cast<TableReader*>(self)->num_rows();
+}
+
+feather_status
+feather_reader_get_column(feather_reader_t* self, int i, feather_column_t* out) {
+  TableReader* reader = reinterpret_cast<TableReader*>(self);
+  std::unique_ptr<Column> col;
+  FEATHER_CHECK_STATUS(reader->GetColumn(i, &col));
+
+  out->type = ToCFeatherColumnType(col->type());
+  out->name = col->name().c_str();
+
+  FEATHER_CHECK_STATUS(ToCFeatherArray(col->values(), &out->values));
+
+  out->data = reinterpret_cast<void*>(col.release());
+
+  return FEATHER_OK;
+}
+
+feather_status
+feather_reader_close(feather_reader_t* self) {
+  return FEATHER_OK;
+}
+
+feather_status
+feather_reader_free(feather_reader_t* self) {
+  delete reinterpret_cast<TableReader*>(self);
+  return FEATHER_OK;
 }
 
 #ifdef __cplusplus

--- a/cpp/src/feather/feather-c.cc
+++ b/cpp/src/feather/feather-c.cc
@@ -16,13 +16,20 @@
 
 #include <cstdlib>
 #include <cstdint>
+#include <string>
 
 #include "feather/reader.h"
 #include "feather/types.h"
 #include "feather/writer.h"
 #include "feather/feather-c.h"
 
-using namespace feather;
+using feather::Column;
+using feather::ColumnType;
+using feather::PrimitiveArray;
+using feather::PrimitiveType;
+using feather::Status;
+using feather::TableReader;
+using feather::TableWriter;
 
 static PrimitiveType::type FromCFeatherType(feather_type ctype) {
   return static_cast<PrimitiveType::type>(static_cast<int>(ctype));

--- a/cpp/src/feather/feather-c.cc
+++ b/cpp/src/feather/feather-c.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2016 Feather Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "feather/reader.h"
+#include "feather/types.h"
+#include "feather/writer.h"
+#include "feather/feather-c.h"
+
+using namespace feather;
+
+#ifdef __cplusplus
+extern "C" {
+#if 0 /* confuse emacs indentation */
+}
+#endif
+#endif
+
+static feather_status get_feather_status (const Status& s) {
+
+}
+
+#define FEATHER_CHECK_STATUS(s) do {                \
+    Status _s = (s);                                \
+    if (!_s.ok()) return get_feather_status(_s);    \
+  } while (0);
+
+#define FEATHER_CHECK_STATUS(s)
+
+feather_status
+feather_reader_open_file(const char* path, feather_reader_t** out) {
+  try {
+    std::string str_path(path);
+    std::unique_ptr<TableReader> reader;
+
+    TableReader::OpenFile(path, &reader);
+
+    *out = reinterpret_cast<feather_reader_t*>(
+  } catch (const std::exception& e) {
+    return FEATHER_OOM;
+  }
+}
+
+#ifdef __cplusplus
+#if 0 /* confuse emacs indentation */
+{
+#endif
+}
+#endif

--- a/cpp/src/feather/feather-c.h
+++ b/cpp/src/feather/feather-c.h
@@ -33,7 +33,8 @@ typedef enum {
   FEATHER_KEY_ERROR = 2,
   FEATHER_INVALID = 3,
   FEATHER_IO_ERROR = 4,
-  FEATHER_NOT_IMPLEMENTED = 10
+  FEATHER_NOT_IMPLEMENTED = 10,
+  FEATHER_UNKNOWN = 50
 } feather_status;
 
 typedef enum {
@@ -108,34 +109,11 @@ typedef struct {
   feather_array_t values;
 
   void* type_metadata;
+  void* data;
 } feather_column_t;
 
 feather_status
 feather_column_free(feather_column_t* self);
-
-/*
- *************************************************
-  TableReader C API
- *************************************************
-*/
-
-typedef void feather_reader_t;
-
-feather_status
-feather_reader_open_file(const char* path, feather_reader_t** out);
-
-int64_t
-feather_reader_num_rows(feather_reader_t* self);
-
-int64_t
-feather_reader_num_columns(feather_reader_t* self);
-
-/*
-  Retrieve the column metadata and data pointers from the file. Call
-  feather_column_free when finished with the column.
- */
-feather_status
-feather_reader_get_column(feather_reader_t* self, int i, feather_column_t** out);
 
 /*
  *************************************************
@@ -175,11 +153,41 @@ feather_writer_append_date(feather_writer_t* self, const char* name,
 
 /* Write file metadata and footer */
 feather_status
-feather_writer_finalize(feather_writer_t* self);
+feather_writer_close(feather_writer_t* self);
 
 /* Close file if any, and deallocate TableWriter */
 feather_status
 feather_writer_free(feather_writer_t* self);
+
+/*
+ *************************************************
+  TableReader C API
+ *************************************************
+*/
+
+typedef void feather_reader_t;
+
+feather_status
+feather_reader_open_file(const char* path, feather_reader_t** out);
+
+int64_t
+feather_reader_num_rows(feather_reader_t* self);
+
+int64_t
+feather_reader_num_columns(feather_reader_t* self);
+
+/*
+ * Retrieve the column metadata and data pointers from the file. Call
+ * feather_column_free when finished with the column.
+ */
+feather_status
+feather_reader_get_column(feather_reader_t* self, int i, feather_column_t* out);
+
+feather_status
+feather_reader_close(feather_reader_t* self);
+
+feather_status
+feather_reader_free(feather_reader_t* self);
 
 #ifdef __cplusplus
 #if 0 /* confuse emacs indentation */

--- a/cpp/src/feather/feather-c.h
+++ b/cpp/src/feather/feather-c.h
@@ -108,8 +108,8 @@ typedef struct {
   const char* name;
   feather_array_t values;
 
-  void* type_metadata;
   void* data;
+  void* type_metadata;
 } feather_column_t;
 
 feather_status

--- a/cpp/src/feather/feather-c.h
+++ b/cpp/src/feather/feather-c.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2016 Feather Developers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FEATHER_FEATHER_C_H
+#define FEATHER_FEATHER_C_H
+
+#ifdef __cplusplus
+extern "C" {
+#if 0 /* confuse emacs indentation */
+}
+#endif
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef enum {
+  FEATHER_OK = 0,
+  FEATHER_OOM = 1,
+  FEATHER_KEY_ERROR = 2,
+  FEATHER_INVALID = 3,
+  FEATHER_IO_ERROR = 4,
+  FEATHER_NOT_IMPLEMENTED = 10
+} feather_status;
+
+typedef enum {
+  FEATHER_BOOL = 0,
+  FEATHER_INT8 = 1,
+  FEATHER_INT16 = 2,
+  FEATHER_INT32 = 3,
+  FEATHER_INT64 = 4,
+  FEATHER_UINT8 = 5,
+  FEATHER_UINT16 = 6,
+  FEATHER_UINT32 = 7,
+  FEATHER_UINT64 = 8,
+  FEATHER_FLOAT = 9,
+  FEATHER_DOUBLE = 10,
+  FEATHER_UTF8 = 11,
+  FEATHER_BINARY = 12
+} feather_type;
+
+/*
+  Column C API
+ */
+
+typedef enum {
+  FEATHER_COLUMN_PRIMITIVE = 0,
+  FEATHER_COLUMN_CATEGORY = 1,
+  FEATHER_COLUMN_TIMESTAMP = 2,
+  FEATHER_COLUMN_DATE = 3,
+  FEATHER_COLUMN_TIME = 4,
+} feather_column_type;
+
+typedef enum {
+  FEATHER_UNIT_SECOND = 0,
+  FEATHER_UNIT_MILLISECOND = 1,
+  FEATHER_UNIT_MICROSECOND = 2,
+  FEATHER_UNIT_NANOSECOND = 3
+} feather_time_unit;
+
+typedef struct {
+  feather_type type;
+  int64_t length;
+  int64_t null_count;
+
+  const uint8_t* nulls;
+  const uint8_t* values;
+
+  const int32_t* offsets;
+} feather_array_t;
+
+typedef struct {
+  feather_array_t indices;
+  feather_array_t levels;
+  int ordered;
+} feather_category_t;
+
+typedef struct {
+  feather_array_t levels;
+  int ordered;
+} feather_category_data_t;
+
+typedef struct {
+  const char* timezone;
+  feather_time_unit unit;
+} feather_timestamp_data_t;
+
+typedef struct {
+  feather_time_unit unit;
+} feather_time_data_t;
+
+typedef struct {
+  feather_column_type type;
+  const char* name;
+  feather_array_t values;
+
+  void* type_metadata;
+} feather_column_t;
+
+feather_status
+feather_column_free(feather_column_t* self);
+
+/*
+ *************************************************
+  TableReader C API
+ *************************************************
+*/
+
+typedef void feather_reader_t;
+
+feather_status
+feather_reader_open_file(const char* path, feather_reader_t** out);
+
+int64_t
+feather_reader_num_rows(feather_reader_t* self);
+
+int64_t
+feather_reader_num_columns(feather_reader_t* self);
+
+/*
+  Retrieve the column metadata and data pointers from the file. Call
+  feather_column_free when finished with the column.
+ */
+feather_status
+feather_reader_get_column(feather_reader_t* self, int i, feather_column_t** out);
+
+/*
+ *************************************************
+  TableWriter C API
+ *************************************************
+*/
+
+typedef void feather_writer_t;
+
+feather_status
+feather_writer_open_file(const char* path, feather_writer_t** out);
+
+void
+feather_writer_set_num_rows(feather_writer_t* self, int64_t num_rows);
+
+/* Write primitive array */
+feather_status
+feather_writer_append_plain(feather_writer_t* self, const char* name,
+    feather_array_t* values);
+
+feather_status
+feather_writer_append_category(feather_writer_t* self, const char* name,
+    feather_array_t* values, feather_array_t* levels, int ordered);
+
+feather_status
+feather_writer_append_timestamp(feather_writer_t* self, const char* name,
+    feather_array_t* values, const char* timezone,
+    feather_time_unit unit);
+
+feather_status
+feather_writer_append_time(feather_writer_t* self, const char* name,
+    feather_array_t* values, feather_time_unit unit);
+
+feather_status
+feather_writer_append_date(feather_writer_t* self, const char* name,
+    feather_array_t* values);
+
+/* Write file metadata and footer */
+feather_status
+feather_writer_finalize(feather_writer_t* self);
+
+/* Close file if any, and deallocate TableWriter */
+feather_status
+feather_writer_free(feather_writer_t* self);
+
+#ifdef __cplusplus
+#if 0 /* confuse emacs indentation */
+{
+#endif
+}
+#endif
+
+#endif /* FEATHER_FEATHER_C_H */

--- a/cpp/src/feather/metadata.cc
+++ b/cpp/src/feather/metadata.cc
@@ -509,6 +509,8 @@ std::shared_ptr<Column> TimestampColumn::Make(const void* fbs_column) {
   // flatbuffer non-null
   if (tz != 0) {
     result->metadata_.timezone = tz->str();
+  } else {
+    result->metadata_.timezone = "";
   }
 
   return result;

--- a/cpp/src/feather/reader.h
+++ b/cpp/src/feather/reader.h
@@ -32,7 +32,9 @@ class Column {
       const PrimitiveArray& values) :
       type_(type),
       metadata_(metadata),
-      values_(values) {}
+      values_(values) {
+    name_ = metadata_->name();
+  }
 
   const PrimitiveArray& values() const {
     return values_;
@@ -46,12 +48,13 @@ class Column {
     return metadata_;
   }
 
-  std::string name() const {
-    return metadata_->name();
+  const std::string& name() const {
+    return name_;
   }
 
  protected:
   ColumnType::type type_;
+  std::string name_;
   std::shared_ptr<metadata::Column> metadata_;
   PrimitiveArray values_;
 };
@@ -88,18 +91,20 @@ class TimestampColumn : public Column {
       const PrimitiveArray& values) :
       Column(ColumnType::TIMESTAMP, metadata, values)  {
     timestamp_meta_ = static_cast<const metadata::TimestampColumn*>(metadata.get());
+    timezone_ = timestamp_meta_->timezone();
   }
 
   TimeUnit::type unit() const {
     return timestamp_meta_->unit();
   }
 
-  std::string timezone() const {
-    return timestamp_meta_->timezone();
+  const std::string& timezone() const {
+    return timezone_;
   }
 
  private:
   const metadata::TimestampColumn* timestamp_meta_;
+  std::string timezone_;
 };
 
 class DateColumn : public Column {
@@ -148,22 +153,22 @@ class TableReader {
   int64_t num_rows() const;
   int64_t num_columns() const;
 
-  Status GetColumn(int i, std::shared_ptr<Column>* out) const;
+  Status GetColumn(int i, std::unique_ptr<Column>* out) const;
 
  private:
   Status GetPrimitive(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out) const;
+      std::unique_ptr<Column>* out) const;
   Status GetCategory(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out) const;
+      std::unique_ptr<Column>* out) const;
 
   Status GetTimestamp(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out) const;
+      std::unique_ptr<Column>* out) const;
 
   Status GetTime(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out) const;
+      std::unique_ptr<Column>* out) const;
 
   Status GetDate(std::shared_ptr<metadata::Column> col_meta,
-      std::shared_ptr<Column>* out) const;
+      std::unique_ptr<Column>* out) const;
 
   // Retrieve a primitive array from the data source
   //

--- a/cpp/src/feather/status.h
+++ b/cpp/src/feather/status.h
@@ -77,6 +77,7 @@ class Status {
   bool IsKeyError() const { return code() == StatusCode::KeyError; }
   bool IsIOError() const { return code() == StatusCode::IOError; }
   bool IsInvalid() const { return code() == StatusCode::Invalid; }
+  bool IsNotImplemented() const { return code() == StatusCode::NotImplemented; }
 
   // Return a string representation of this status suitable for printing.
   // Returns the string "OK" for success.

--- a/cpp/src/feather/tests/c-api-test.cc
+++ b/cpp/src/feather/tests/c-api-test.cc
@@ -30,11 +30,10 @@
     ASSERT_EQ(FEATHER_OK, _s);                  \
   } while (0);
 
-using namespace feather;
+namespace feather {
 
 class TestCAPI : public ::testing::Test {
  public:
-
   virtual void TearDown() {
     for (const std::string& path : tmp_paths_) {
       try {
@@ -82,7 +81,6 @@ TEST_F(TestCAPI, FileNotExist) {
 }
 
 TEST_F(TestCAPI, WriteNumRows) {
-
   const int num_rows = 1000;
 
   std::string path("test-cfeather-write-num-rows");
@@ -189,3 +187,5 @@ TEST_F(TestCAPI, PrimitiveRoundTrip) {
 
   CloseReader();
 }
+
+} // namespace feather

--- a/cpp/src/feather/tests/c-api-test.cc
+++ b/cpp/src/feather/tests/c-api-test.cc
@@ -1,0 +1,157 @@
+// Copyright 2016 Feather Developers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdio>
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "feather/common.h"
+#include "feather/feather-c.h"
+#include "feather/tests/test-common.h"
+
+#define ASSERT_CFEATHER_OK(s) do {              \
+    feather_status _s = (s);                    \
+    ASSERT_EQ(FEATHER_OK, _s);                  \
+  } while (0);
+
+using namespace feather;
+
+class TestCAPI : public ::testing::Test {
+ public:
+
+  virtual void TearDown() {
+    for (const std::string& path : tmp_paths_) {
+      try {
+        std::remove(path.c_str());
+      } catch (const std::exception& e) {}
+    }
+  }
+
+  void OpenWriter(const std::string& path) {
+    const char* c_path = path.c_str();
+    tmp_paths_.push_back(path);
+
+    ASSERT_CFEATHER_OK(feather_writer_open_file(c_path, &writer_));
+  }
+
+  void CloseWriter() {
+    ASSERT_CFEATHER_OK(feather_writer_close(writer_));
+    ASSERT_CFEATHER_OK(feather_writer_free(writer_));
+  }
+
+  void OpenReader(const std::string& path) {
+    ASSERT_CFEATHER_OK(feather_reader_open_file(path.c_str(), &reader_));
+  }
+
+  void CloseReader() {
+    ASSERT_CFEATHER_OK(feather_reader_close(reader_));
+    ASSERT_CFEATHER_OK(feather_reader_free(reader_));
+  }
+
+ protected:
+  std::vector<std::string> tmp_paths_;
+
+  feather_writer_t* writer_;
+  feather_reader_t* reader_;
+};
+
+TEST_F(TestCAPI, FileNotExist) {
+  feather_status s;
+  feather_reader_t* reader;
+
+  const char* path = "file-not-exist.feather";
+
+  s = feather_reader_open_file(path, &reader);
+  ASSERT_EQ(FEATHER_IO_ERROR, s);
+}
+
+TEST_F(TestCAPI, WriteNumRows) {
+
+  const int num_rows = 1000;
+
+  std::string path("test-cfeather-write-num-rows");
+
+  OpenWriter(path);
+  feather_writer_set_num_rows(writer_, num_rows);
+  CloseWriter();
+
+  OpenReader(path);
+  ASSERT_EQ(num_rows, feather_reader_num_rows(reader_));
+  CloseReader();
+}
+
+void MakePrimitive(feather_type type,
+    int64_t length, int64_t null_count,
+    const uint8_t* nulls, const uint8_t* values,
+    const int32_t* offsets, feather_array_t* out) {
+  out->type = type;
+  out->length = length;
+  out->null_count = null_count;
+  out->nulls = nulls;
+  out->values = values;
+  out->offsets = offsets;
+}
+
+TEST_F(TestCAPI, PrimitiveRoundTrip) {
+  int num_values = 1000;
+  int num_nulls = 50;
+  int null_bytes = util::bytes_for_bits(num_values);
+
+    // Generate some random data
+  vector<uint8_t> null_buffer;
+  vector<uint8_t> values_buffer;
+  test::random_bytes(null_bytes, 0, &null_buffer);
+  test::random_bytes(num_values * sizeof(int32_t), 0, &values_buffer);
+
+  feather_array_t cvalues;
+  feather_array_t cvalues_nn;
+
+  MakePrimitive(FEATHER_INT32, num_values, num_nulls, &null_buffer[0],
+      &values_buffer[0], nullptr, &cvalues);
+
+  // A non-nullable version of this
+  MakePrimitive(FEATHER_UINT32, num_values, 0, nullptr, &values_buffer[0],
+      nullptr, &cvalues_nn);
+
+  std::string path("test-cfeather-primitive-round-trip");
+
+  OpenWriter(path);
+
+  const char* name0 = "f0";
+  const char* name1 = "f1";
+
+  ASSERT_CFEATHER_OK(feather_writer_append_plain(writer_, name0, &cvalues));
+  ASSERT_CFEATHER_OK(feather_writer_append_plain(writer_, name1, &cvalues_nn));
+
+  CloseWriter();
+
+  OpenReader(path);
+
+  feather_column_t col;
+  ASSERT_CFEATHER_OK(feather_reader_get_column(reader_, 0, &col));
+  ASSERT_EQ(FEATHER_COLUMN_PRIMITIVE, col.type);
+  ASSERT_STREQ(name0, col.name);
+
+  feather_column_free(&col);
+
+  ASSERT_CFEATHER_OK(feather_reader_get_column(reader_, 1, &col));
+  ASSERT_STREQ(name1, col.name);
+  feather_column_free(&col);
+
+  CloseReader();
+}

--- a/cpp/src/feather/tests/writer-test.cc
+++ b/cpp/src/feather/tests/writer-test.cc
@@ -121,7 +121,7 @@ TEST_F(TestTableWriter, PrimitiveRoundTrip) {
   ASSERT_OK(writer_->AppendPlain("f1", nn_array));
   Finish();
 
-  std::shared_ptr<Column> col;
+  std::unique_ptr<Column> col;
   ASSERT_OK(reader_->GetColumn(0, &col));
   ASSERT_TRUE(col->values().Equals(array));
   ASSERT_EQ("f0", col->metadata()->name());
@@ -154,7 +154,7 @@ TEST_F(TestTableWriter, CategoryRoundtrip) {
   ASSERT_OK(writer_->AppendCategory("f0", values, levels, true));
   Finish();
 
-  std::shared_ptr<Column> col;
+  std::unique_ptr<Column> col;
   ASSERT_OK(reader_->GetColumn(0, &col));
   ASSERT_EQ("f0", col->metadata()->name());
   ASSERT_EQ(ColumnType::CATEGORY, col->type());
@@ -186,7 +186,7 @@ TEST_F(TestTableWriter, TimestampRoundtrip) {
   ASSERT_OK(writer_->AppendTimestamp("f0", values, metadata));
   Finish();
 
-  std::shared_ptr<Column> col;
+  std::unique_ptr<Column> col;
   ASSERT_OK(reader_->GetColumn(0, &col));
   ASSERT_EQ("f0", col->metadata()->name());
   ASSERT_EQ(ColumnType::TIMESTAMP, col->type());
@@ -214,7 +214,7 @@ TEST_F(TestTableWriter, DateRoundtrip) {
   ASSERT_OK(writer_->AppendDate("f0", values));
   Finish();
 
-  std::shared_ptr<Column> col;
+  std::unique_ptr<Column> col;
   ASSERT_OK(reader_->GetColumn(0, &col));
   ASSERT_EQ("f0", col->metadata()->name());
   ASSERT_EQ(ColumnType::DATE, col->type());
@@ -240,7 +240,7 @@ TEST_F(TestTableWriter, TimeRoundtrip) {
   ASSERT_OK(writer_->AppendTime("f0", values, metadata));
   Finish();
 
-  std::shared_ptr<Column> col;
+  std::unique_ptr<Column> col;
   ASSERT_OK(reader_->GetColumn(0, &col));
   ASSERT_EQ("f0", col->metadata()->name());
   ASSERT_EQ(ColumnType::TIME, col->type());
@@ -275,7 +275,7 @@ TEST_F(TestTableWriter, VLenPrimitiveRoundTrip) {
   ASSERT_OK(writer_->AppendPlain("f1", nn_array));
   Finish();
 
-  std::shared_ptr<Column> col;
+  std::unique_ptr<Column> col;
   ASSERT_OK(reader_->GetColumn(0, &col));
   ASSERT_TRUE(col->values().Equals(array));
   ASSERT_EQ("f0", col->metadata()->name());

--- a/python/feather/ext.pyx
+++ b/python/feather/ext.pyx
@@ -168,7 +168,7 @@ cdef class FeatherReader:
 
     def read_array(self, int i):
         cdef:
-            shared_ptr[Column] col
+            unique_ptr[Column] col
             Column* cp
 
         if i < 0 or i >= self.num_columns:

--- a/python/feather/libfeather.pxd
+++ b/python/feather/libfeather.pxd
@@ -197,4 +197,4 @@ cdef extern from "feather/api.h" namespace "feather" nogil:
         int64_t num_rows()
         int64_t num_columns()
 
-        Status GetColumn(int i, shared_ptr[Column]* out)
+        Status GetColumn(int i, unique_ptr[Column]* out)


### PR DESCRIPTION
Spurred by Julia and others needing a non-C++ API for libfeather, I drafted something simple that should be a good start. @dmbates can you take a look and let me know if this will work for you all? See `feather/feather-c.h`

I believe C users will need to perform the link step with g++ for this to work.

```shell
$ nm -g debug/libfeather.so | grep feather_
0000000000050565 T feather_column_free
00000000000508e2 T feather_reader_close
00000000000508f1 T feather_reader_free
0000000000050731 T feather_reader_get_column
0000000000050717 T feather_reader_num_rows
000000000005059b T feather_reader_open_file
000000000005030c T feather_writer_append_plain
00000000000504d4 T feather_writer_close
0000000000050533 T feather_writer_free
000000000005016b T feather_writer_open_file
00000000000502e7 T feather_writer_set_num_rows
```