### PR TITLE
[Dev] Specify the travis build directory as the git root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,5 +107,6 @@ matrix:
 
 before_install:
 - export FEATHER_CPP=$TRAVIS_BUILD_DIR/cpp
-- mkdir $HOME/build_dir
-- cd $HOME/build_dir
+- export BUILD_DIR=$TRAVIS_BUILD_DIR/build_dir
+- mkdir $BUILD_DIR
+- cd $BUILD_DIR

--- a/cpp/ci/before_script_travis.sh
+++ b/cpp/ci/before_script_travis.sh
@@ -6,7 +6,6 @@ cp -r $FEATHER_CPP/thirdparty .
 source thirdparty/versions.sh
 
 # this is created in Travis CI
-export BUILD_DIR=$HOME/build_dir
 export TP_DIR=$BUILD_DIR/thirdparty
 
 if [ $TRAVIS_OS_NAME == "osx" ]; then


### PR DESCRIPTION
Because we build outside the git tree the upload script was not able to
find the coverage files properly.

This is I believe why we were not seeing C++ coverage on codecov properly.