### PR TITLE
Fixes cast from double to int64 to prevent loss of precision.

### DIFF
--- a/R/src/feather-write.cpp
+++ b/R/src/feather-write.cpp
@@ -163,7 +163,7 @@ PrimitiveArray rescaleToInt64(SEXP x, int64_t scale) {
       } else {
         // Valid
         util::set_bit(nulls, i);
-        values[i] = px[i] * scale;
+        values[i] = round(px[i] * scale);
       }
     }
     break;


### PR DESCRIPTION
With this fix all unit tests pass on windows. I think it might also fix the problem on Solaris.

The problem was that the implicit cast from double to int64 results in rounding error on 32 bit platforms.