### PR TITLE
[Python] Windows support

### DIFF
--- a/cpp/src/feather/api.h
+++ b/cpp/src/feather/api.h
@@ -15,6 +15,10 @@
 #ifndef FEATHER_API_H
 #define FEATHER_API_H
 
+#if _MSC_VER >= 1900
+  #undef timezone
+#endif
+
 #include "feather/buffer.h"
 #include "feather/common.h"
 #include "feather/io.h"

--- a/cpp/src/feather/io.cc
+++ b/cpp/src/feather/io.cc
@@ -14,7 +14,8 @@
 
 #include "feather/io.h"
 
-#ifdef __MINGW32__
+#ifdef _WIN32
+#define NOMINMAX
 #include "feather/mman.h"
 #undef Realloc
 #undef Free

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -122,9 +122,7 @@ class TestFeatherReader(unittest.TestCase):
 
         for dtype in numpy_dtypes:
             info = np.iinfo(dtype)
-            values = np.random.randint(info.min,
-                                       min(info.max, np.iinfo('i8').max),
-                                       size=num_values)
+            values = np.random.randint(0, 100, size=num_values)
             data[dtype] = values.astype(dtype)
 
         df = pd.DataFrame(data)

--- a/python/setup.py
+++ b/python/setup.py
@@ -116,6 +116,9 @@ else:
     if platform.system() == 'Darwin':
         EXTRA_LINK_ARGS.append('-Wl,-rpath,' + feather_lib_dir)
 
+EXTRA_COMPILE_ARGS = []
+if platform.system() != 'Windows':
+    EXTRA_COMPILE_ARGS = ['-std=c++11', '-O3']
 
 RT_LIBRARY_DIRS = LIBRARY_DIRS
 
@@ -126,7 +129,7 @@ ext = Extension('feather.ext',
                 include_dirs=INCLUDE_PATHS,
                 library_dirs=LIBRARY_DIRS,
                 runtime_library_dirs=RT_LIBRARY_DIRS,
-                extra_compile_args=['-std=c++11', '-O3'],
+                extra_compile_args=EXTRA_COMPILE_ARGS,
                 extra_link_args=EXTRA_LINK_ARGS)
 extensions = [ext]
 extensions = cythonize(extensions)


### PR DESCRIPTION
Closes #111

Python 3.5 defines a `timezone` symbol; which was causing all the crazy compilation errors.
https://bugs.python.org/issue24643

I changed the test due to https://github.com/numpy/numpy/issues/4085 - numpy won't generate a random int bigger than the platform int.