### PR TITLE
Force dummy pointer for zero length vectors

### DIFF
--- a/cpp/src/feather/buffer.cc
+++ b/cpp/src/feather/buffer.cc
@@ -33,7 +33,9 @@ OwnedMutableBuffer::OwnedMutableBuffer() {}
 Status OwnedMutableBuffer::Resize(int64_t new_size) {
   size_ = new_size;
   try {
-    buffer_owner_.resize(new_size);
+    if(new_size == 0 && buffer_owner_.data() == NULL)
+      buffer_owner_.resize(1); //create dummy pointer for empty vectors
+    buffer_owner_.resize(new_size); //resize to actual size
   } catch (const std::bad_alloc& e) {
     return Status::OutOfMemory("allocation failed");
   }


### PR DESCRIPTION
Fixes https://github.com/wesm/feather/issues/170.

The problem is that `buffer_owner_.resize(0)` equals `malloc(0)` which returns `NULL`. This workaround first allocates one byte, and the resizes the space to 0. This ensures we always get a valid pointer.