### PR TITLE
[C++] Add Win32 / POSIX compatibility layer for consistent handling of files over 2 GB

### DIFF
--- a/cpp/src/feather/buffer.cc
+++ b/cpp/src/feather/buffer.cc
@@ -35,7 +35,7 @@ Status OwnedMutableBuffer::Resize(int64_t new_size) {
   try {
     buffer_owner_.resize(new_size);
   } catch (const std::bad_alloc& e) {
-    return Status::OutOfMemory("allocation failed");
+    return Status::OutOfMemory(e.what());
   }
   data_ = buffer_owner_.data();
   mutable_data_ = buffer_owner_.data();

--- a/cpp/src/feather/common.h
+++ b/cpp/src/feather/common.h
@@ -32,7 +32,7 @@ static inline int64_t bytes_for_bits(int64_t size) {
 static constexpr uint8_t BITMASK[] = {1, 2, 4, 8, 16, 32, 64, 128};
 
 static inline bool get_bit(const uint8_t* bits, int i) {
-  return static_cast<bool>(bits[i / 8] & BITMASK[i % 8]);
+  return (bits[i / 8] & BITMASK[i % 8]) != 0;
 }
 
 static inline bool bit_not_set(const uint8_t* bits, int i) {

--- a/cpp/src/feather/feather-c.cc
+++ b/cpp/src/feather/feather-c.cc
@@ -112,6 +112,7 @@ feather_writer_open_file(const char* path, feather_writer_t** out) {
     std::string str_path(path);
     FEATHER_CHECK_STATUS(TableWriter::OpenFile(str_path, &writer));
   } catch (const std::exception& e) {
+    (void) e;
     return FEATHER_OOM;
   }
   *out = reinterpret_cast<feather_writer_t*>(writer.release());
@@ -134,6 +135,7 @@ feather_writer_append_plain(feather_writer_t* self, const char* name,
     std::string cpp_name(name);
     return get_feather_status(writer->AppendPlain(cpp_name, cpp_values));
   } catch (const std::exception& e) {
+    (void) e;
     return FEATHER_OOM;
   }
 }
@@ -165,6 +167,7 @@ feather_reader_open_file(const char* path, feather_reader_t** out) {
     std::string str_path(path);
     FEATHER_CHECK_STATUS(TableReader::OpenFile(str_path, &reader));
   } catch (const std::exception& e) {
+    (void) e;
     return FEATHER_OOM;
   }
   *out = reinterpret_cast<feather_reader_t*>(reader.release());

--- a/cpp/src/feather/io.cc
+++ b/cpp/src/feather/io.cc
@@ -74,6 +74,7 @@
 #include <algorithm>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <sstream>
 
 // ----------------------------------------------------------------------

--- a/cpp/src/feather/io.h
+++ b/cpp/src/feather/io.h
@@ -18,15 +18,15 @@
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
-#include <stdio.h>
 #include <string>
-#include <vector>
-
-#include "feather/buffer.h"
 
 namespace feather {
 
+class Buffer;
+class OwnedMutableBuffer;
 class Status;
+
+class FileInterface;
 
 // ----------------------------------------------------------------------
 // Input interfaces
@@ -37,7 +37,7 @@ class RandomAccessReader {
  public:
   virtual ~RandomAccessReader() {}
 
-  virtual int64_t Tell() const = 0;
+  virtual Status Tell(int64_t* pos) const = 0;
   virtual Status Seek(int64_t pos) = 0;
 
   // Read data from source at position (seeking if necessary), returning copy
@@ -61,27 +61,19 @@ class RandomAccessReader {
 // level seek and read calls.
 class LocalFileReader : public RandomAccessReader {
  public:
-  LocalFileReader() :
-      file_(nullptr),
-      is_open_(false) {}
+  LocalFileReader();
 
   virtual ~LocalFileReader();
 
   Status Open(const std::string& path);
   void CloseFile();
 
-  virtual int64_t Tell() const;
-  virtual Status Seek(int64_t pos);
-
-  virtual Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out);
-
-  bool is_open() const { return is_open_;}
-  const std::string& path() const { return path_;}
+  Status Tell(int64_t* pos) const override;
+  Status Seek(int64_t pos) override;
+  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
  protected:
-  std::string path_;
-  FILE* file_;
-  bool is_open_;
+  std::unique_ptr<FileInterface> impl_;
 };
 
 class MemoryMapReader : public LocalFileReader {
@@ -96,12 +88,9 @@ class MemoryMapReader : public LocalFileReader {
   Status Open(const std::string& path);
   void CloseFile();
 
-  virtual int64_t Tell() const;
-  virtual Status Seek(int64_t pos);
-  virtual Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out);
-
-  bool is_open() const { return is_open_;}
-  const std::string& path() const { return path_;}
+  Status Tell(int64_t* pos) const override;
+  Status Seek(int64_t pos) override;
+  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
  private:
   uint8_t* data_;
@@ -112,17 +101,11 @@ class MemoryMapReader : public LocalFileReader {
 // A file-like object that reads from virtual address space
 class BufferReader : public RandomAccessReader {
  public:
-  explicit BufferReader(const std::shared_ptr<Buffer>& buffer) :
-      buffer_(buffer),
-      data_(buffer->data()),
-      pos_(0) {
-    size_ = buffer->size();
-  }
+  explicit BufferReader(const std::shared_ptr<Buffer>& buffer);
 
-  virtual int64_t Tell() const;
-  virtual Status Seek(int64_t pos);
-
-  virtual Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out);
+  Status Tell(int64_t* pos) const override;
+  Status Seek(int64_t pos) override;
+  Status Read(int64_t nbytes, std::shared_ptr<Buffer>* out) override;
 
  protected:
   const uint8_t* Head() {
@@ -141,10 +124,11 @@ class BufferReader : public RandomAccessReader {
 class OutputStream {
  public:
   virtual ~OutputStream() {}
+
   // Close the output stream
   virtual Status Close() = 0;
 
-  virtual int64_t Tell() const = 0;
+  virtual Status Tell(int64_t* pos) const = 0;
 
   virtual Status Write(const uint8_t* data, int64_t length) = 0;
 };
@@ -155,11 +139,11 @@ class InMemoryOutputStream : public OutputStream {
  public:
   explicit InMemoryOutputStream(int64_t initial_capacity);
 
-  virtual Status Close();
+  virtual ~InMemoryOutputStream() {}
 
-  virtual int64_t Tell() const;
-
-  virtual Status Write(const uint8_t* data, int64_t length);
+  Status Close() override;
+  Status Tell(int64_t* pos) const override;
+  Status Write(const uint8_t* data, int64_t length) override;
 
   // Hand off the buffered data to a new owner
   std::shared_ptr<Buffer> Finish();
@@ -174,24 +158,20 @@ class InMemoryOutputStream : public OutputStream {
 
 class FileOutputStream : public OutputStream {
  public:
-  FileOutputStream():
-      file_(nullptr), is_open_(false) {}
+  FileOutputStream();
+  ~FileOutputStream();
 
   Status Open(const std::string& path);
 
-  virtual Status Close();
-
-  virtual int64_t Tell() const;
-
-  virtual Status Write(const uint8_t* data, int64_t length);
+  Status Close() override;
+  Status Tell(int64_t* pos) const override;
+  Status Write(const uint8_t* data, int64_t length) override;
 
   // Hand off the buffered data to a new owner
   std::shared_ptr<Buffer> Finish();
 
  private:
-  std::string path_;
-  FILE* file_;
-  bool is_open_;
+  std::unique_ptr<FileInterface> impl_;
 };
 
 } // namespace feather

--- a/cpp/src/feather/metadata.cc
+++ b/cpp/src/feather/metadata.cc
@@ -421,7 +421,7 @@ size_t Table::num_columns() const {
   return table->columns()->size();
 }
 
-std::shared_ptr<Column> Table::GetColumn(size_t i) const {
+std::shared_ptr<Column> Table::GetColumn(int i) const {
   const fbs::CTable* table = static_cast<const fbs::CTable*>(table_);
   const fbs::Column* col = table->columns()->Get(i);
 

--- a/cpp/src/feather/metadata.h
+++ b/cpp/src/feather/metadata.h
@@ -161,7 +161,7 @@ class Table {
   int64_t num_rows() const;
 
   size_t num_columns() const;
-  std::shared_ptr<Column> GetColumn(size_t i) const;
+  std::shared_ptr<Column> GetColumn(int i) const;
   std::shared_ptr<Column> GetColumnNamed(const std::string& name) const;
 
  private:

--- a/cpp/src/feather/reader.cc
+++ b/cpp/src/feather/reader.cc
@@ -29,7 +29,7 @@ TableReader::TableReader() {}
 Status TableReader::Open(const std::shared_ptr<RandomAccessReader>& source) {
   source_ = source;
 
-  int magic_size = strlen(FEATHER_MAGIC_BYTES);
+  int magic_size = static_cast<int>(strlen(FEATHER_MAGIC_BYTES));
   int footer_size = magic_size + sizeof(uint32_t);
 
   // Pathological issue where the file is smaller than

--- a/cpp/src/feather/status.cc
+++ b/cpp/src/feather/status.cc
@@ -18,7 +18,7 @@ namespace feather {
 
 Status::Status(StatusCode code, const std::string& msg, int16_t posix_code) {
   assert(code != StatusCode::OK);
-  const uint32_t size = msg.size();
+  const uint32_t size = static_cast<uint32_t>(msg.size());
   char* result = new char[size + 7];
   memcpy(result, &size, sizeof(size));
   result[4] = static_cast<char>(code);

--- a/cpp/src/feather/tests/c-api-test.cc
+++ b/cpp/src/feather/tests/c-api-test.cc
@@ -38,7 +38,9 @@ class TestCAPI : public ::testing::Test {
     for (const std::string& path : tmp_paths_) {
       try {
         std::remove(path.c_str());
-      } catch (const std::exception& e) {}
+      } catch (const std::exception& e) {
+        (void) e;
+      }
     }
   }
 
@@ -138,7 +140,7 @@ bool cfeather_array_equals(const feather_array_t* lhs, const feather_array_t* rh
 TEST_F(TestCAPI, PrimitiveRoundTrip) {
   int num_values = 1000;
   int num_nulls = 50;
-  int null_bytes = util::bytes_for_bits(num_values);
+  int64_t null_bytes = util::bytes_for_bits(num_values);
 
     // Generate some random data
   vector<uint8_t> null_buffer;

--- a/cpp/src/feather/tests/io-test.cc
+++ b/cpp/src/feather/tests/io-test.cc
@@ -30,19 +30,26 @@ TEST(TestBufferReader, Basics) {
   auto data_buffer = std::make_shared<Buffer>(&data[0], data.size());
   std::unique_ptr<BufferReader> reader(new BufferReader(data_buffer));
 
-  ASSERT_EQ(0, reader->Tell());
+  int64_t pos;
+  ASSERT_OK(reader->Tell(&pos));
+
+  ASSERT_EQ(0, pos);
   ASSERT_EQ(10, reader->size());
 
   std::shared_ptr<Buffer> buffer;
   ASSERT_OK(reader->Read(4, &buffer));
   ASSERT_EQ(4, buffer->size());
   ASSERT_EQ(0, memcmp(buffer->data(), &data[0], buffer->size()));
-  ASSERT_EQ(4, reader->Tell());
+
+  ASSERT_OK(reader->Tell(&pos));
+  ASSERT_EQ(4, pos);
 
   ASSERT_OK(reader->Read(10, &buffer));
   ASSERT_EQ(6, buffer->size());
   ASSERT_EQ(0, memcmp(buffer->data(), &data[4], buffer->size()));
-  ASSERT_EQ(10, reader->Tell());
+
+  ASSERT_OK(reader->Tell(&pos));
+  ASSERT_EQ(10, pos);
 }
 
 TEST(TestInMemoryOutputStream, Basics) {
@@ -51,7 +58,12 @@ TEST(TestInMemoryOutputStream, Basics) {
   std::vector<uint8_t> data = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
   ASSERT_OK(stream->Write(&data[0], 4));
-  ASSERT_EQ(4, stream->Tell());
+
+  int64_t pos;
+  ASSERT_OK(stream->Tell(&pos));
+
+  ASSERT_EQ(4, pos);
+
   ASSERT_OK(stream->Write(&data[4], data.size() - 4));
 
   std::shared_ptr<Buffer> buffer = stream->Finish();

--- a/cpp/src/feather/tests/test-common.h
+++ b/cpp/src/feather/tests/test-common.h
@@ -54,7 +54,7 @@ inline void assert_vector_equal(const vector<T>& left,
   }
 }
 
-static inline void random_bytes(int n, uint32_t seed, std::vector<uint8_t>* out) {
+static inline void random_bytes(int64_t n, uint32_t seed, std::vector<uint8_t>* out) {
   std::mt19937 gen(seed);
   std::uniform_int_distribution<int> d(0, 255);
 
@@ -63,7 +63,7 @@ static inline void random_bytes(int n, uint32_t seed, std::vector<uint8_t>* out)
   }
 }
 
-static inline void random_vlen_bytes(int n, int max_value_size, uint32_t seed,
+static inline void random_vlen_bytes(int64_t n, int max_value_size, uint32_t seed,
     std::vector<int32_t>* offsets, std::vector<uint8_t>* values) {
   std::mt19937 gen(seed);
 

--- a/cpp/src/feather/tests/writer-test.cc
+++ b/cpp/src/feather/tests/writer-test.cc
@@ -102,7 +102,7 @@ PrimitiveArray MakePrimitive(PrimitiveType::type type,
 TEST_F(TestTableWriter, PrimitiveRoundTrip) {
   int num_values = 1000;
   int num_nulls = 50;
-  int null_bytes = util::bytes_for_bits(num_values);
+  int64_t null_bytes = util::bytes_for_bits(num_values);
 
     // Generate some random data
   vector<uint8_t> null_buffer;
@@ -135,7 +135,7 @@ TEST_F(TestTableWriter, CategoryRoundtrip) {
   int num_values = 1000;
   int num_nulls = 50;
   int num_levels = 10;
-  int null_bytes = util::bytes_for_bits(num_values);
+  int64_t null_bytes = util::bytes_for_bits(num_values);
 
     // Generate some random data
   vector<uint8_t> null_buffer;
@@ -168,7 +168,7 @@ TEST_F(TestTableWriter, CategoryRoundtrip) {
 TEST_F(TestTableWriter, TimestampRoundtrip) {
   int num_values = 1000;
   int num_nulls = 50;
-  int null_bytes = util::bytes_for_bits(num_values);
+  int64_t null_bytes = util::bytes_for_bits(num_values);
 
     // Generate some random data
   vector<uint8_t> null_buffer;
@@ -200,7 +200,7 @@ TEST_F(TestTableWriter, TimestampRoundtrip) {
 TEST_F(TestTableWriter, DateRoundtrip) {
   int num_values = 1000;
   int num_nulls = 50;
-  int null_bytes = util::bytes_for_bits(num_values);
+  int64_t null_bytes = util::bytes_for_bits(num_values);
 
     // Generate some random data
   vector<uint8_t> null_buffer;
@@ -224,7 +224,7 @@ TEST_F(TestTableWriter, DateRoundtrip) {
 TEST_F(TestTableWriter, TimeRoundtrip) {
   int num_values = 1000;
   int num_nulls = 50;
-  int null_bytes = util::bytes_for_bits(num_values);
+  int64_t null_bytes = util::bytes_for_bits(num_values);
 
     // Generate some random data
   vector<uint8_t> null_buffer;
@@ -254,7 +254,7 @@ TEST_F(TestTableWriter, VLenPrimitiveRoundTrip) {
   // UTF8 or BINARY
   int num_values = 1000;
   int num_nulls = 50;
-  int null_bytes = util::bytes_for_bits(num_values);
+  int64_t null_bytes = util::bytes_for_bits(num_values);
 
     // Generate some random data
   vector<uint8_t> null_buffer;

--- a/cpp/src/feather/writer.cc
+++ b/cpp/src/feather/writer.cc
@@ -67,7 +67,7 @@ Status TableWriter::Finalize() {
   // Writer metadata
   RETURN_NOT_OK(stream_->Write(buffer->data(), buffer->size()));
 
-  uint32_t buffer_size = buffer->size();
+  uint32_t buffer_size = static_cast<uint32_t>(buffer->size());
 
   // Footer: metadata length, magic bytes
   RETURN_NOT_OK(stream_->Write(reinterpret_cast<const uint8_t*>(&buffer_size),
@@ -86,7 +86,9 @@ Status TableWriter::AppendPrimitive(const PrimitiveArray& values,
   }
   meta->type = values.type;
   meta->encoding = Encoding::PLAIN;
-  meta->offset = stream_->Tell();
+
+  RETURN_NOT_OK(stream_->Tell(&meta->offset));
+
   meta->length = values.length;
   meta->null_count = values.null_count;
   meta->total_bytes = 0;

--- a/python/scripts/large_file_test.py
+++ b/python/scripts/large_file_test.py
@@ -1,0 +1,48 @@
+# Copyright 2016 Feather Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+import numpy as np
+
+from pandas.util.testing import assert_frame_equal
+import pandas as pd
+
+import feather
+
+import uuid
+
+nrows = 4000000
+ncols = 100
+
+data = np.random.randn(nrows)
+
+df = pd.DataFrame({'c{0}'.format(i): data
+                   for i in range(ncols)})
+
+def guid():
+    return uuid.uuid4().hex
+
+path = 'test_{0}.feather'.format(guid())
+
+try:
+    feather.write_dataframe(df, path)
+    df2 = feather.read_dataframe(path)
+    assert_frame_equal(df, df2)
+finally:
+    try:
+        os.remove(path)
+    except os.error:
+        pass

--- a/python/scripts/win_update_src.cmd
+++ b/python/scripts/win_update_src.cmd
@@ -1,0 +1,1 @@
+xcopy ..\cpp\src src /s /e /y


### PR DESCRIPTION
To properly do this, I had to make usages of `cstdio` "private" and push down the file interactions into a private implementation. 

Per #155 
Per #120 

I've tested locally that this fixes the observed Windows failure on files > 2 GB. I will ask others to verify before I close the issues.