### PR TITLE
[R] Fix windows development build

### DIFF
--- a/R/.Rbuildignore
+++ b/R/.Rbuildignore
@@ -3,3 +3,4 @@
 ^src/feather/.*\.o$
 ^src/.*\.a$
 ^cran-comments\.md$
+^configure.win$

--- a/R/configure.win
+++ b/R/configure.win
@@ -1,0 +1,5 @@
+# This script is only needed for testing on Windows
+# It is not included with CRAN releases
+rm -Rf src/feather
+rm -Rf src/flatbuffers
+cp -Rf ../cpp/src/* src/

--- a/cpp/src/feather/io.cc
+++ b/cpp/src/feather/io.cc
@@ -15,7 +15,9 @@
 #include "feather/io.h"
 
 #ifdef _WIN32
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include "feather/mman.h"
 #undef Realloc
 #undef Free


### PR DESCRIPTION
The `configure.win` script copies the c++ files into the R package because Windows does not understand the symlinks. This makes it possible to install the source package on windows straight from git. 

Note that this is not needed for released versions of feather because `R CMD build` already replaces symlinks with actual content in the source package. Hence `configure.win` in `.Rbuildignore`.