### PR TITLE
[C++] Help feather + R work with older gccs

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -22,5 +22,5 @@ Imports:
 Suggests:
     testthat,
     dplyr
-SystemRequirements: C++11, little-endian platform
+SystemRequirements: gcc-compatible compiler, little-endian platform
 RoxygenNote: 5.0.1

--- a/R/src/Makevars
+++ b/R/src/Makevars
@@ -1,5 +1,4 @@
-CXX_STD=CXX11
-PKG_CPPFLAGS=-I.
+PKG_CPPFLAGS=-std=c++0x -I.
 PKG_LIBS=-L. -lfeather
 
 LIBFEATHER=feather/buffer.o feather/feather-c.o feather/io.o feather/metadata.o \

--- a/cpp/src/feather/buffer.h
+++ b/cpp/src/feather/buffer.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <vector>
 
+#include "feather/compatibility.h"
 #include "feather/status.h"
 
 namespace feather {
@@ -143,7 +144,7 @@ class BufferBuilder {
     } else {
       result = buffer_;
     }
-    buffer_ = nullptr;
+    buffer_.reset();
     return result;
   }
 

--- a/cpp/src/feather/common.h
+++ b/cpp/src/feather/common.h
@@ -15,6 +15,8 @@
 #ifndef FEATHER_COMMON_H
 #define FEATHER_COMMON_H
 
+#include "feather/compatibility.h"
+
 namespace feather {
 
 static constexpr const char* FEATHER_MAGIC_BYTES = "FEA1";

--- a/cpp/src/feather/compatibility.h
+++ b/cpp/src/feather/compatibility.h
@@ -21,13 +21,14 @@
 
 #  define FEATHER_CPP0X_COMPATIBLE
 
-#  ifndef nullptr
-const class nullptr_t {
+#  ifndef nullptr_t
+const class feather_nullptr_t {
 public:
   template<class T> inline operator T*() const { return 0; }
 private:
   void operator&() const; // NOLINT
 } nullptr = {};
+#   define nullptr_t feather_nullptr_t
 #  endif
 
 #  define constexpr

--- a/cpp/src/feather/compatibility.h
+++ b/cpp/src/feather/compatibility.h
@@ -12,21 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FEATHER_API_H
-#define FEATHER_API_H
+#ifndef FEATHER_COMPATIBILITY_H_
+#define FEATHER_COMPATIBILITY_H_
 
-#if _MSC_VER >= 1900
-  #undef timezone
+// Compatibility for older versions of gcc without full C++11 support
+#if defined(__GNUC__) && !defined(__clang__)
+# if __GNUC__ == 4 && __GNUC_MINOR__ < 6
+
+#  define FEATHER_CPP0X_COMPATIBLE
+
+#  ifndef nullptr
+const class nullptr_t {
+public:
+  template<class T> inline operator T*() const { return 0; }
+private:
+  void operator&() const;
+} nullptr = {};
+#  endif
+
+#  define constexpr
+#  define override
+
+# endif
 #endif
 
-#include "feather/compatibility.h"
-#include "feather/buffer.h"
-#include "feather/common.h"
-#include "feather/io.h"
-#include "feather/metadata.h"
-#include "feather/reader.h"
-#include "feather/status.h"
-#include "feather/types.h"
-#include "feather/writer.h"
-
-#endif // FEATHER_API_H
+#endif /* FEATHER_COMPATIBILITY_H_ */

--- a/cpp/src/feather/compatibility.h
+++ b/cpp/src/feather/compatibility.h
@@ -26,7 +26,7 @@ const class nullptr_t {
 public:
   template<class T> inline operator T*() const { return 0; }
 private:
-  void operator&() const;
+  void operator&() const; // NOLINT
 } nullptr = {};
 #  endif
 

--- a/cpp/src/feather/io.cc
+++ b/cpp/src/feather/io.cc
@@ -467,7 +467,7 @@ Status MemoryMapReader::Tell(int64_t* pos) const {
 
 Status MemoryMapReader::Read(int64_t nbytes, std::shared_ptr<Buffer>* out) {
   nbytes = std::min(nbytes, size_ - pos_);
-  *out = std::make_shared<Buffer>(data_ + pos_, nbytes);
+  *out = std::shared_ptr<Buffer>(new Buffer(data_ + pos_, nbytes));
   return Status::OK();
 }
 
@@ -514,7 +514,7 @@ Status InMemoryOutputStream::Tell(int64_t* pos) const {
 std::shared_ptr<Buffer> InMemoryOutputStream::Finish() {
   buffer_->Resize(size_);
   std::shared_ptr<Buffer> result = buffer_;
-  buffer_ = nullptr;
+  buffer_.reset();
 
   // TODO(wesm): raise exceptions if user calls Write after Finish
   size_ = 0;

--- a/cpp/src/feather/io.h
+++ b/cpp/src/feather/io.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <string>
 
+#include "feather/compatibility.h"
+
 namespace feather {
 
 class Buffer;

--- a/cpp/src/feather/metadata.cc
+++ b/cpp/src/feather/metadata.cc
@@ -326,7 +326,7 @@ class ColumnBuilder::Impl {
 
   // Type-specific metadata union
   CategoryMetadata meta_category_;
-  DateMetadata meta_date_;
+  // DateMetadata meta_date_; // not used?
   TimeMetadata meta_time_;
 
   TimestampMetadata meta_timestamp_;

--- a/cpp/src/feather/metadata.cc
+++ b/cpp/src/feather/metadata.cc
@@ -26,10 +26,8 @@ namespace metadata {
 
 typedef flatbuffers::FlatBufferBuilder FBB;
 
-using FBString = flatbuffers::Offset<flatbuffers::String>;
-
-// Flatbuffers conveniences
-using ColumnVector = std::vector<flatbuffers::Offset<fbs::Column>>;
+typedef flatbuffers::Offset<flatbuffers::String> FBString;
+typedef std::vector<flatbuffers::Offset<fbs::Column>> ColumnVector;
 
 // ----------------------------------------------------------------------
 // Primitive array
@@ -186,8 +184,9 @@ TableBuilder::TableBuilder(int64_t num_rows) {
   impl_.reset(new Impl(num_rows));
 }
 
-TableBuilder::TableBuilder() :
-    TableBuilder(0) {}
+TableBuilder::TableBuilder() {
+  impl_.reset(new Impl(0));
+}
 
 std::shared_ptr<Buffer> TableBuilder::GetBuffer() const {
   return std::make_shared<Buffer>(impl_->fbb().GetBufferPointer(),
@@ -326,11 +325,9 @@ class ColumnBuilder::Impl {
   ColumnType::type type_;
 
   // Type-specific metadata union
-  union {
-    CategoryMetadata meta_category_;
-    DateMetadata meta_date_;
-    TimeMetadata meta_time_;
-  };
+  CategoryMetadata meta_category_;
+  DateMetadata meta_date_;
+  TimeMetadata meta_time_;
 
   TimestampMetadata meta_timestamp_;
 
@@ -441,12 +438,12 @@ std::shared_ptr<Column> Table::GetColumn(int i) const {
       break;
   }
   // suppress compiler warning
-  return std::shared_ptr<Column>(nullptr);
+  return std::shared_ptr<Column>();
 }
 
 std::shared_ptr<Column> Table::GetColumnNamed(const std::string& name) const {
   // Not yet implemented
-  return std::shared_ptr<Column>(nullptr);
+  return std::shared_ptr<Column>();
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/feather/metadata.h
+++ b/cpp/src/feather/metadata.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "feather/compatibility.h"
 #include "feather/buffer.h"
 #include "feather/types.h"
 

--- a/cpp/src/flatbuffers/flatbuffers.h
+++ b/cpp/src/flatbuffers/flatbuffers.h
@@ -39,11 +39,9 @@
   #error __cplusplus _MSC_VER __GNUC__  __GNUC_MINOR__  __GNUC_PATCHLEVEL__
 #endif
 
-#if !defined(FEATHER_CPP0X_COMPATIBLE) && \
-    !defined(__clang__) && \
+#if !defined(__clang__) && \
     defined(__GNUC__) && \
     (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__ < 40600)
-
   // Backwards compatability for g++ 4.4, and 4.5 which don't have the nullptr and constexpr
   // keywords. Note the __clang__ check is needed, because clang presents itself as an older GNUC
   // compiler.

--- a/cpp/src/flatbuffers/flatbuffers.h
+++ b/cpp/src/flatbuffers/flatbuffers.h
@@ -39,9 +39,11 @@
   #error __cplusplus _MSC_VER __GNUC__  __GNUC_MINOR__  __GNUC_PATCHLEVEL__
 #endif
 
-#if !defined(__clang__) && \
+#if !defined(FEATHER_CPP0X_COMPATIBLE) && \
+    !defined(__clang__) && \
     defined(__GNUC__) && \
     (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__ < 40600)
+
   // Backwards compatability for g++ 4.4, and 4.5 which don't have the nullptr and constexpr
   // keywords. Note the __clang__ check is needed, because clang presents itself as an older GNUC
   // compiler.


### PR DESCRIPTION
This PR tries to add a minimal set of compatibility macros + changes to help feather build with gcc 4.4. This would help ensure `feather` could work / build on e.g. RHEL 6, which is fairly ubiquitous in the enterprise world.