### PR TITLE
[R] resolve R CMD check issues

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -23,5 +23,5 @@ Imports:
 Suggests:
     testthat,
     dplyr
-SystemRequirements: gcc-compatible compiler, little-endian platform
+SystemRequirements: little-endian platform
 RoxygenNote: 5.0.1

--- a/R/src/Makevars
+++ b/R/src/Makevars
@@ -1,4 +1,5 @@
-PKG_CPPFLAGS=-std=c++0x -I.
+CXX_STD = CXX11
+PKG_CPPFLAGS = -I.
 PKG_LIBS=-L. -lfeather
 
 LIBFEATHER=feather/buffer.o feather/feather-c.o feather/io.o feather/metadata.o \


### PR DESCRIPTION
This PR resolves an `R CMD check` issue where setting `-std=c++0x` triggers a new warning in R-devel.

Note that, for users of R with older gccs, they will likely need to manually set their own CXX1X and CXX1XSTD variables in a `~/.R/Makevars` file, e.g. I have:

```
CXX1X=g++-4.4
CXX1XSTD=-std=c++0x
```

If we hear from RHEL users with older gccs, we should just instruct them to do this.