### PR TITLE
[R/Python] Metadata handling tweaks, implement `columns` filter argument in Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,19 +77,6 @@ matrix:
 
   - os: linux
     language: python
-    python: 3.4
-    compiler: gcc
-    before_install:
-    - cd python
-    - ln -s ../cpp/src src
-    install:
-    - pip install cython
-    - pip install -r requirements.txt
-    script: python setup.py test
-    env: TRAVIS_LANG=python
-
-  - os: linux
-    language: python
     python: 3.5
     compiler: gcc
     before_install:

--- a/R/src/feather-read.cpp
+++ b/R/src/feather-read.cpp
@@ -21,18 +21,25 @@ std::unique_ptr<Column> getColumn(const TableReader& table, int i) {
   return col;
 }
 
+std::shared_ptr<metadata::Column> getColumnMetadata(const TableReader& table,
+    int i) {
+  std::shared_ptr<metadata::Column> meta;
+  stopOnFailure(table.GetColumnMetadata(i, &meta));
+  return meta;
+}
+
 // [[Rcpp::export]]
 List metadataFeather(const std::string& path) {
-  auto table = openFeatherTable(path);
+  std::unique_ptr<TableReader> table = openFeatherTable(path);
 
   int n = table->num_rows(), p = table->num_columns();
   CharacterVector types(p), names(p);
 
   for (int j = 0; j < p; ++j) {
-    auto col = getColumn(*table, j);
+    auto meta = getColumnMetadata(*table, j);
 
-    names[j] = Rf_mkCharCE(col->name().c_str(), CE_UTF8);
-    types[j] = toString(toRColType(col));
+    names[j] = Rf_mkCharCE(meta->name().c_str(), CE_UTF8);
+    types[j] = toString(toRColType(meta->type(), meta->values_type()));
   }
   types.attr("names") = names;
 
@@ -53,9 +60,8 @@ CharacterVector colnamesAsCharacterVector(const TableReader& table) {
   CharacterVector names(n);
 
   for (int i = 0; i < n; ++i) {
-    auto col = getColumn(table, i);
-
-    names[i] = Rf_mkCharCE(col->name().c_str(), CE_UTF8);
+    auto meta = getColumnMetadata(table, i);
+    names[i] = Rf_mkCharCE(meta->name().c_str(), CE_UTF8);
   }
 
   return names;

--- a/R/src/feather-types.cpp
+++ b/R/src/feather-types.cpp
@@ -4,7 +4,7 @@ using namespace Rcpp;
 #include "feather-types.h"
 using namespace feather;
 
-RColType toRColType(FeatherColType x) {
+RColType toRColType(FeatherPrimitiveType x) {
   switch(x) {
   case PrimitiveType::BOOL:
     return R_LGL;
@@ -28,10 +28,10 @@ RColType toRColType(FeatherColType x) {
   throw std::runtime_error("Invalid FeatherColType");
 }
 
-RColType toRColType(const ColumnPtr& x) {
-  switch(x->type()) {
+RColType toRColType(FeatherColumnType col_type, FeatherPrimitiveType primitive_type) {
+  switch(col_type) {
   case feather::ColumnType::PRIMITIVE:
-    return toRColType(x->metadata()->values().type);
+    return toRColType(primitive_type);
   case feather::ColumnType::CATEGORY:
     return R_FACTOR;
   case feather::ColumnType::TIMESTAMP:

--- a/R/src/feather-types.h
+++ b/R/src/feather-types.h
@@ -1,7 +1,8 @@
 #include <Rcpp.h>
 #include "feather/api.h"
 
-typedef feather::PrimitiveType::type FeatherColType;
+typedef feather::PrimitiveType::type FeatherPrimitiveType;
+typedef feather::ColumnType::type FeatherColumnType;
 typedef std::unique_ptr<feather::Column> ColumnPtr;
 typedef std::shared_ptr<feather::metadata::Column> ColumnMetadataPtr;
 
@@ -17,8 +18,9 @@ enum RColType {
   R_TIME
 };
 
-RColType toRColType(FeatherColType x);
-RColType toRColType(const ColumnPtr& x);
+RColType toRColType(FeatherPrimitiveType x);
+RColType toRColType(FeatherColumnType column_type,
+    FeatherPrimitiveType primitive_type);
 
 std::string toString(RColType x);
 SEXP toSEXP(const ColumnPtr& x);

--- a/cpp/src/feather/metadata.cc
+++ b/cpp/src/feather/metadata.cc
@@ -484,6 +484,11 @@ ColumnType::type Column::type() const {
   return type_;
 }
 
+PrimitiveType::type Column::values_type() const {
+  return values_.type;
+}
+
+
 std::string Column::user_metadata() const {
   return user_metadata_;
 }

--- a/cpp/src/feather/metadata.h
+++ b/cpp/src/feather/metadata.h
@@ -87,6 +87,8 @@ class Column {
   std::string name() const;
   ColumnType::type type() const;
 
+  PrimitiveType::type values_type() const;
+
   std::string user_metadata() const;
 
   const ArrayMetadata& values() const {

--- a/cpp/src/feather/reader.cc
+++ b/cpp/src/feather/reader.cc
@@ -208,4 +208,10 @@ Status TableReader::GetColumn(int i, std::unique_ptr<Column>* out) const {
   return Status::OK();
 }
 
+Status TableReader::GetColumnMetadata(int i,
+    std::shared_ptr<metadata::Column>* out) const {
+  *out = metadata_.GetColumn(i);
+  return Status::OK();
+}
+
 } // namespace feather

--- a/cpp/src/feather/reader.h
+++ b/cpp/src/feather/reader.h
@@ -157,6 +157,8 @@ class TableReader {
 
   Status GetColumn(int i, std::unique_ptr<Column>* out) const;
 
+  Status GetColumnMetadata(int i, std::shared_ptr<metadata::Column>* out) const;
+
  private:
   Status GetPrimitive(std::shared_ptr<metadata::Column> col_meta,
       std::unique_ptr<Column>* out) const;

--- a/python/feather/api.py
+++ b/python/feather/api.py
@@ -15,10 +15,11 @@
 import six
 from distutils.version import LooseVersion
 import pandas as pd
-if LooseVersion(pd.__version__) < '0.17.0':
-    raise ImportError("feather requires pandas >= 0.17.0")
 
 import feather.ext as ext
+
+if LooseVersion(pd.__version__) < '0.17.0':
+    raise ImportError("feather requires pandas >= 0.17.0")
 
 
 def write_dataframe(df, path):
@@ -46,12 +47,14 @@ def read_dataframe(path, columns=None):
     Parameters
     ----------
     path : string, path to read from
-    columns : optional, array-like, containing list of columns to read, or None to read all columns
+    columns : sequence, optional
+        Only read a specific set of columns. If not provided, all columns are
+        read
 
     Returns
     -------
     df : pandas.DataFrame
-    """ 
+    """
     reader = ext.FeatherReader(path)
 
     if columns is not None:
@@ -61,9 +64,10 @@ def read_dataframe(path, columns=None):
     data = {}
     names = []
     for i in range(reader.num_columns):
-        name = reader.get_column_name(i)
+        col = reader.get_column(i)
+        name = col.name
         if columns is None or name in columns:
-            name, arr = reader.read_array(i)
+            arr = col.read()
             data[name] = arr
             names.append(name)
 

--- a/python/feather/api.py
+++ b/python/feather/api.py
@@ -43,19 +43,29 @@ def read_dataframe(path, columns=None):
     """
     Read a pandas.DataFrame from Feather format
 
+    Parameters
+    ----------
+    path : string, path to read from
+    columns : optional, array-like, containing list of columns to read, or None to read all columns
+
     Returns
     -------
     df : pandas.DataFrame
-    """
+    """ 
     reader = ext.FeatherReader(path)
+
+    if columns is not None:
+        columns = set(columns)
 
     # TODO(wesm): pipeline conversion to Arrow memory layout
     data = {}
     names = []
     for i in range(reader.num_columns):
-        name, arr = reader.read_array(i)
-        data[name] = arr
-        names.append(name)
+        name = reader.get_column_name(i)
+        if columns is None or name in columns:
+            name, arr = reader.read_array(i)
+            data[name] = arr
+            names.append(name)
 
     # TODO(wesm):
     return pd.DataFrame(data, columns=names)

--- a/python/feather/ext.pyx
+++ b/python/feather/ext.pyx
@@ -190,6 +190,18 @@ cdef class FeatherReader:
 
         return frombytes(cp.name()), values
 
+    def get_column_name(self, int i):
+        cdef:
+            unique_ptr[Column] col
+            Column* cp
+
+        if i < 0 or i >= self.num_columns:
+            raise IndexError(i)
+
+        check_status(self.reader.get().GetColumn(i, &col))
+        cp = col.get()
+        return frombytes(cp.name())
+
 
 cdef category_to_pandas(Column* col):
     cdef CategoryColumn* cat = <CategoryColumn*>(col)

--- a/python/feather/libfeather.pxd
+++ b/python/feather/libfeather.pxd
@@ -173,15 +173,20 @@ cdef extern from "feather/api.h" namespace "feather" nogil:
 
         Status Finalize()
 
-    cdef cppclass Column:
+    cdef cppclass CColumn" feather::Column":
         const PrimitiveArray& values()
         ColumnType type()
         string name()
 
-    cdef cppclass CategoryColumn(Column):
+    cdef cppclass CColumnMetadata" feather::metadata::Column":
+        string name() const
+        ColumnType type() const
+        string user_metadata() const
+
+    cdef cppclass CategoryColumn(CColumn):
         const PrimitiveArray& levels()
 
-    cdef cppclass TimestampColumn(Column):
+    cdef cppclass TimestampColumn(CColumn):
         TimeUnit unit()
         string timezone()
 
@@ -197,4 +202,5 @@ cdef extern from "feather/api.h" namespace "feather" nogil:
         int64_t num_rows()
         int64_t num_columns()
 
-        Status GetColumn(int i, unique_ptr[Column]* out)
+        Status GetColumn(int i, unique_ptr[CColumn]* out)
+        Status GetColumnMetadata(int i, shared_ptr[CColumnMetadata]* out)

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -54,7 +54,7 @@ class TestFeatherReader(unittest.TestCase):
         if not os.path.exists(path):
             raise Exception('file not written')
 
-        result = feather.read_dataframe(path)
+        result = feather.read_dataframe(path, columns)
         if expected is None:
             expected = df
 
@@ -254,3 +254,12 @@ class TestFeatherReader(unittest.TestCase):
         name = (b'Besa_Kavaj\xc3\xab.feather').decode('utf-8')
         df = pd.DataFrame({'foo': [1, 2, 3, 4]})
         self._check_pandas_roundtrip(df, path=name)
+
+    def test_read_columns(self):
+        data = {'foo': [1,2,3,4],
+                'boo': [5,6,7,8],
+                'woo': [1,3,5,7]}
+        columns = list(data.keys())[1:3]
+        df = pd.DataFrame(data)
+        expected = pd.DataFrame({c:data[c] for c in columns})
+        self._check_pandas_roundtrip(df, expected, columns)

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -45,7 +45,8 @@ class TestFeatherReader(unittest.TestCase):
         with self.assertRaises(feather.FeatherError):
             FeatherReader('test_invalid_file')
 
-    def _check_pandas_roundtrip(self, df, expected=None, path=None):
+    def _check_pandas_roundtrip(self, df, expected=None, path=None,
+                                columns=None):
         if path is None:
             path = random_path()
 
@@ -262,4 +263,4 @@ class TestFeatherReader(unittest.TestCase):
         columns = list(data.keys())[1:3]
         df = pd.DataFrame(data)
         expected = pd.DataFrame({c:data[c] for c in columns})
-        self._check_pandas_roundtrip(df, expected, columns)
+        self._check_pandas_roundtrip(df, expected, columns=columns)


### PR DESCRIPTION
Both the Python and R code were using `TableReader::GetColumn` to access column metadata which causes data to be read from the file. This is OK when we are using memory maps but will cause performance problems should we switch to some other file-like object. I added a `GetColumnMetadata` API and refactored both Python and R codebases to use this

Closes #208