### PR TITLE
Workaround for Error Messages

### DIFF
--- a/R/configure
+++ b/R/configure
@@ -1,5 +1,5 @@
 # Check for little-endian system
-R_ENDIAN=`${R_HOME}/bin/Rscript -e 'cat(.Platform$endian)'`
+R_ENDIAN=`${R_HOME}/bin/Rscript -e 'suppressWarnings(cat(.Platform$endian))'`
 if [ "$R_ENDIAN" = "little" ]; then
     echo "Platform is little endian. Good."
     exit 0


### PR DESCRIPTION
This a quick patch to avoid a pathology in the installation process.

Under certain conditions, Rscript gives a warning message of:

    WARNING: ignoring environment value of R_HOME

When there seems to be a (valid but unusual) setup of R_HOME when it 
tries to determine the system endianess.  As a result, the command to 
determine the endianess of the system returns

    WARNING: ignoring environment value of R_HOME little

instead of just “little”. causing this script to think it is big endian when it 
isn’t.  

This pull request runs the command wrapped in a suppressWarnings call
 so that only the platform endianess and not the warning is returned.