### PR TITLE
[R] Workaround for Error Messages

### DIFF
--- a/R/configure
+++ b/R/configure
@@ -1,5 +1,7 @@
 # Check for little-endian system
 R_ENDIAN=`${R_HOME}/bin/Rscript -e 'cat(.Platform$endian)'`
+# Trim off any warning messages that Rscript appends in front of the platform endianness
+R_ENDIAN=`expr "$R_ENDIAN" : '.*\(little\)$'`
 if [ "$R_ENDIAN" = "little" ]; then
     echo "Platform is little endian. Good."
     exit 0


### PR DESCRIPTION
Under certain conditions, Rscript gives a warning message of:

    WARNING: ignoring environment value of R_HOME

When there seems to be a valid but unusual setup of R_HOME.  As a
result, the command to determine the endianess of the system returns

    WARNING: ignoring environment value of R_HOME little

instead of just “little”. causing this script to think it is big
endian when it isn’t.  This pull changes the configure script to
remove this warning message before checking the endianness.