### PR TITLE
[Python] Change expected values in test_strings and test_category

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,41 @@ matrix:
     language: python
     python: 2.7
     compiler: gcc
+    env:
+      - TRAVIS_LANG=python
+      - PANDAS_VERSION=0.18.0
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install cython
+    - pip install pandas==$PANDAS_VERSION
+    - pip install -r requirements.txt
+    script: python setup.py test
+
+  - os: linux
+    language: python
+    python: 3.5
+    compiler: gcc
+    env:
+      - TRAVIS_LANG=python
+      - PANDAS_VERSION=0.18.0
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install codecov
+    - pip install cython
+    - pip install pandas==$PANDAS_VERSION
+    - pip install -r requirements.txt
+    script: coverage run setup.py test
+    after_success:
+      codecov
+
+  - os: linux
+    language: python
+    python: 2.7
+    compiler: gcc
     before_install:
     - cd python
     - ln -s ../cpp/src src

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -215,7 +215,7 @@ class TestFeatherReader(unittest.TestCase):
         values = [b'foo', None, u'bar', 'qux', np.nan]
         df = pd.DataFrame({'strings': values * repeats})
 
-        values = ['foo', None, u'bar', 'qux', None]
+        values = ['foo', None, 'bar', 'qux', None]
         expected = pd.DataFrame({'strings': values * repeats})
         self._check_pandas_roundtrip(df, expected)
 
@@ -234,7 +234,10 @@ class TestFeatherReader(unittest.TestCase):
         values = ['foo', None, u'bar', 'qux', np.nan]
         df = pd.DataFrame({'strings': values * repeats})
         df['strings'] = df['strings'].astype('category')
-        self._check_pandas_roundtrip(df)
+
+        values = ['foo', None, 'bar', 'qux', None]
+        expected = pd.DataFrame({'strings': pd.Categorical(values * repeats)})
+        self._check_pandas_roundtrip(df,expected)
 
     def test_timestamp(self):
         df = pd.DataFrame({'naive': pd.date_range('2016-03-28', periods=10)})


### PR DESCRIPTION
I noticed a test failure while looking at contributing on #235 (Deprecations in pandas 0.19 means moving to the public API ).

* In test_strings, this is not blocking but more reflective of what is written to disk
* In test_category, this test erratically fails on Python 2.7

I isolated the 2.7 python section in the travis file to highlight the test failure:
[https://travis-ci.org/guillett/feather/builds/166061964](url)

Then I updated the tests to pass the tests
[https://travis-ci.org/guillett/feather/builds/166066370](url)

Rationale for updating test_strings:
I run the following snippet:
```python
import pandas as pd
values = ['foo', None, u'bar', 'qux', None]

def dtype(v):
	try:
		return pd.lib.infer_dtype(v)
	except TypeError as e:
		return '##ERROR'

print(values)
print([dtype(v) for v in values])
print('')
import feather
path = 'strings.feather'
feather.write_dataframe(pd.DataFrame({'strings': values}),path)
df = feather.read_dataframe(path)
print(df.strings.values)
print([dtype(v) for v in df.strings.values])
```
Python 2.7:
```python
['foo', None, u'bar', 'qux', None]
['string', '##ERROR', 'unicode', 'string', '##ERROR']

['foo' None 'bar' 'qux' None]
['string', '##ERROR', 'string', 'string', '##ERROR']
```
Python 3.5
```python
['foo', None, 'bar', 'qux', None]
['string', '##ERROR', 'string', 'string', '##ERROR']

['foo' None 'bar' 'qux' None]
['string', '##ERROR', 'string', 'string', '##ERROR']
```
The Unicode item is directly converted to string by Python 3.5 and the type of the data loaded from disk is *string* for both Python versions.



