### PR TITLE
[Python] Type check for Categorical and Datetime relies on pandas public API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,41 @@ matrix:
     language: python
     python: 2.7
     compiler: gcc
+    env:
+      - TRAVIS_LANG=python
+      - PANDAS_VERSION=0.18.0
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install cython
+    - pip install pandas==$PANDAS_VERSION
+    - pip install -r requirements.txt
+    script: python setup.py test
+
+  - os: linux
+    language: python
+    python: 3.5
+    compiler: gcc
+    env:
+      - TRAVIS_LANG=python
+      - PANDAS_VERSION=0.18.0
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install codecov
+    - pip install cython
+    - pip install pandas==$PANDAS_VERSION
+    - pip install -r requirements.txt
+    script: coverage run setup.py test
+    after_success:
+      codecov
+
+  - os: linux
+    language: python
+    python: 2.7
+    compiler: gcc
     before_install:
     - cd python
     - ln -s ../cpp/src src

--- a/python/feather/compat.py
+++ b/python/feather/compat.py
@@ -108,3 +108,10 @@ def guid():
 
 
 integer_types = six.integer_types + (np.integer,)
+
+from distutils.version import LooseVersion
+import pandas
+if LooseVersion(pandas.__version__) < '0.19.0':
+    pdapi = pandas.core.common
+else:
+    pdapi = pandas.api.types

--- a/python/feather/ext.pyx
+++ b/python/feather/ext.pyx
@@ -24,7 +24,7 @@ from cython.operator cimport dereference as deref
 from libfeather cimport *
 
 import pandas as pd
-import pandas.api.types as pdapi
+from feather.compat import pdapi
 
 from numpy cimport ndarray
 cimport numpy as cnp

--- a/python/feather/ext.pyx
+++ b/python/feather/ext.pyx
@@ -24,7 +24,7 @@ from cython.operator cimport dereference as deref
 from libfeather cimport *
 
 import pandas as pd
-import pandas.core.common as pdcom
+import pandas.api.types as pdapi
 
 from numpy cimport ndarray
 cimport numpy as cnp
@@ -81,9 +81,9 @@ cdef class FeatherWriter:
         else:
             self.num_rows = len(col)
 
-        if pdcom.is_categorical_dtype(col.dtype):
+        if pdapi.is_categorical_dtype(col.dtype):
             self.write_category(name, col, mask)
-        elif pdcom.is_datetime64_any_dtype(col.dtype):
+        elif pdapi.is_datetime64_any_dtype(col.dtype):
             self.write_timestamp(name, col, mask)
         else:
             self.write_primitive(name, col, mask)

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -215,7 +215,7 @@ class TestFeatherReader(unittest.TestCase):
         values = [b'foo', None, u'bar', 'qux', np.nan]
         df = pd.DataFrame({'strings': values * repeats})
 
-        values = ['foo', None, u'bar', 'qux', None]
+        values = ['foo', None, 'bar', 'qux', None]
         expected = pd.DataFrame({'strings': values * repeats})
         self._check_pandas_roundtrip(df, expected)
 
@@ -234,7 +234,10 @@ class TestFeatherReader(unittest.TestCase):
         values = ['foo', None, u'bar', 'qux', np.nan]
         df = pd.DataFrame({'strings': values * repeats})
         df['strings'] = df['strings'].astype('category')
-        self._check_pandas_roundtrip(df)
+
+        values = ['foo', None, 'bar', 'qux', None]
+        expected = pd.DataFrame({'strings': pd.Categorical(values * repeats)})
+        self._check_pandas_roundtrip(df,expected)
 
     def test_timestamp(self):
         df = pd.DataFrame({'naive': pd.date_range('2016-03-28', periods=10)})


### PR DESCRIPTION
Fixes #235. Depends on #238.

Substitutions as per advised by the warning message.