### PR TITLE
[Python] Fix bug (read and write) with missing value for Categorical

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,41 @@ matrix:
     language: python
     python: 2.7
     compiler: gcc
+    env:
+      - TRAVIS_LANG=python
+      - PANDAS_VERSION=0.18.0
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install cython
+    - pip install pandas==$PANDAS_VERSION
+    - pip install -r requirements.txt
+    script: python setup.py test
+
+  - os: linux
+    language: python
+    python: 3.5
+    compiler: gcc
+    env:
+      - TRAVIS_LANG=python
+      - PANDAS_VERSION=0.18.0
+    before_install:
+    - cd python
+    - ln -s ../cpp/src src
+    install:
+    - pip install codecov
+    - pip install cython
+    - pip install pandas==$PANDAS_VERSION
+    - pip install -r requirements.txt
+    script: coverage run setup.py test
+    after_success:
+      codecov
+
+  - os: linux
+    language: python
+    python: 2.7
+    compiler: gcc
     before_install:
     - cd python
     - ln -s ../cpp/src src

--- a/python/feather/compat.py
+++ b/python/feather/compat.py
@@ -108,3 +108,10 @@ def guid():
 
 
 integer_types = six.integer_types + (np.integer,)
+
+from distutils.version import LooseVersion
+import pandas
+if LooseVersion(pandas.__version__) < '0.19.0':
+    pdapi = pandas.core.common
+else:
+    pdapi = pandas.api.types

--- a/python/feather/ext.pyx
+++ b/python/feather/ext.pyx
@@ -24,7 +24,7 @@ from cython.operator cimport dereference as deref
 from libfeather cimport *
 
 import pandas as pd
-import pandas.api.types as pdapi
+from feather.compat import pdapi
 
 from numpy cimport ndarray
 cimport numpy as cnp

--- a/python/feather/ext.pyx
+++ b/python/feather/ext.pyx
@@ -24,7 +24,7 @@ from cython.operator cimport dereference as deref
 from libfeather cimport *
 
 import pandas as pd
-import pandas.core.common as pdcom
+import pandas.api.types as pdapi
 
 from numpy cimport ndarray
 cimport numpy as cnp
@@ -81,9 +81,9 @@ cdef class FeatherWriter:
         else:
             self.num_rows = len(col)
 
-        if pdcom.is_categorical_dtype(col.dtype):
+        if pdapi.is_categorical_dtype(col.dtype):
             self.write_category(name, col, mask)
-        elif pdcom.is_datetime64_any_dtype(col.dtype):
+        elif pdapi.is_datetime64_any_dtype(col.dtype):
             self.write_timestamp(name, col, mask)
         else:
             self.write_primitive(name, col, mask)

--- a/python/feather/ext.pyx
+++ b/python/feather/ext.pyx
@@ -181,6 +181,17 @@ cdef class Column:
         def __get__(self):
             return frombytes(self.mp.user_metadata())
 
+    property null_count:
+        def __get__(self):
+            cdef:
+                unique_ptr[CColumn] col
+                CColumn* cp
+
+            check_status(self.parent.reader.get()
+                .GetColumn(self.column_index, &col))
+
+            return col.get().values().null_count
+
     def read(self):
         cdef:
             unique_ptr[CColumn] col

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -215,7 +215,7 @@ class TestFeatherReader(unittest.TestCase):
         values = [b'foo', None, u'bar', 'qux', np.nan]
         df = pd.DataFrame({'strings': values * repeats})
 
-        values = ['foo', None, u'bar', 'qux', None]
+        values = ['foo', None, 'bar', 'qux', None]
         expected = pd.DataFrame({'strings': values * repeats})
         self._check_pandas_roundtrip(df, expected)
 
@@ -234,7 +234,10 @@ class TestFeatherReader(unittest.TestCase):
         values = ['foo', None, u'bar', 'qux', np.nan]
         df = pd.DataFrame({'strings': values * repeats})
         df['strings'] = df['strings'].astype('category')
-        self._check_pandas_roundtrip(df)
+
+        values = ['foo', None, 'bar', 'qux', None]
+        expected = pd.DataFrame({'strings': pd.Categorical(values * repeats)})
+        self._check_pandas_roundtrip(df,expected)
 
     def test_timestamp(self):
         df = pd.DataFrame({'naive': pd.date_range('2016-03-28', periods=10)})

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -15,6 +15,7 @@
 import os
 import unittest
 
+from numpy.testing import assert_array_equal
 import numpy as np
 
 from pandas.util.testing import assert_frame_equal
@@ -45,8 +46,18 @@ class TestFeatherReader(unittest.TestCase):
         with self.assertRaises(feather.FeatherError):
             FeatherReader('test_invalid_file')
 
+    def _get_null_counts(self, path, columns=None):
+        reader = FeatherReader(path)
+        counts = []
+        for i in range(reader.num_columns):
+            col = reader.get_column(i)
+            if columns == None or col.name in columns:
+                counts.append(col.null_count)
+
+        return counts
+
     def _check_pandas_roundtrip(self, df, expected=None, path=None,
-                                columns=None):
+                                columns=None, null_counts=None):
         if path is None:
             path = random_path()
 
@@ -60,6 +71,11 @@ class TestFeatherReader(unittest.TestCase):
             expected = df
 
         assert_frame_equal(result, expected)
+
+        if null_counts is None:
+            null_counts = np.zeros(len(expected.columns))
+
+        np.testing.assert_array_equal(self._get_null_counts(path, columns), null_counts)
 
     def test_num_rows_attr(self):
         df = pd.DataFrame({'foo': [1, 2, 3, 4, 5]})
@@ -100,6 +116,7 @@ class TestFeatherReader(unittest.TestCase):
         null_mask = np.random.randint(0, 10, size=num_values) < 3
         dtypes = ['f4', 'f8']
         expected_cols = []
+        null_counts = []
         for name in dtypes:
             values = np.random.randn(num_values).astype(name)
             writer.write_array(name, values, null_mask)
@@ -107,6 +124,7 @@ class TestFeatherReader(unittest.TestCase):
             values[null_mask] = np.nan
 
             expected_cols.append(values)
+            null_counts.append(null_mask.sum())
 
         writer.close()
 
@@ -115,6 +133,7 @@ class TestFeatherReader(unittest.TestCase):
 
         result = feather.read_dataframe(path)
         assert_frame_equal(result, ex_frame)
+        assert_array_equal(self._get_null_counts(path), null_counts)
 
     def test_integer_no_nulls(self):
         data = {}
@@ -206,9 +225,10 @@ class TestFeatherReader(unittest.TestCase):
         assert_frame_equal(result, ex_frame)
 
     def test_boolean_object_nulls(self):
-        arr = np.array([False, None, True] * 100, dtype=object)
+        repeats = 100
+        arr = np.array([False, None, True] * repeats, dtype=object)
         df = pd.DataFrame({'bools': arr})
-        self._check_pandas_roundtrip(df)
+        self._check_pandas_roundtrip(df, null_counts=[1 * repeats])
 
     def test_strings(self):
         repeats = 1000
@@ -217,7 +237,7 @@ class TestFeatherReader(unittest.TestCase):
 
         values = ['foo', None, 'bar', 'qux', None]
         expected = pd.DataFrame({'strings': values * repeats})
-        self._check_pandas_roundtrip(df, expected)
+        self._check_pandas_roundtrip(df, expected, null_counts=[2 * repeats])
 
     def test_empty_strings(self):
         df = pd.DataFrame({'strings': [''] * 10})
@@ -237,7 +257,7 @@ class TestFeatherReader(unittest.TestCase):
 
         values = ['foo', None, 'bar', 'qux', None]
         expected = pd.DataFrame({'strings': pd.Categorical(values * repeats)})
-        self._check_pandas_roundtrip(df,expected)
+        result = self._check_pandas_roundtrip(df,expected, null_counts=[2 * repeats])
 
     def test_timestamp(self):
         df = pd.DataFrame({'naive': pd.date_range('2016-03-28', periods=10)})


### PR DESCRIPTION
That PR fixes the incorrect handling of nan in Categorical (as described in #230).
Depends on #239.

The Python implementation do not *read* nor *write* nan properly (but manage to understand nan written to disk in Python).

Currently:
* nan in a file is replaced (in Python) by the value of the first category
* nan in a dataframe is stored as -1 in a file

In the first commit, I added a property to Column in order to get the number of nulls and use it in tests.
In the second commit, I fix the bugs on reading and writing and make tests pass.

The first commit generates tests that fail and the second one fixes the tests.
Should I invert the two commits? Have a single commit?

### Details:
Here are some snippets that highlight the underlying behavior and the origin on the bug:
```python
import numpy as np
import pandas as pd
pd.Categorical(np.array([0,-1.0,-1]),categories=['a'],fastpath=True)
```
returns
```python
[a, NaN, a]
Categories (1, object): [a]
```
when we expect:
```python
[a, NaN, NaN]
Categories (1, object): [a]
```

That is because:
```python
np.array(np.array([0,-1,np.nan]),dtype=np.int8)
```
returns
```python
array([ 0, -1,  0], dtype=int8)
```
