### PR TITLE
[Python] Fix bug with missing value for Datetime

### DIFF
--- a/python/feather/interop.h
+++ b/python/feather/interop.h
@@ -588,7 +588,7 @@ class FeatherDeserializer {
       double* out_values = reinterpret_cast<double*>(PyArray_DATA(out_));
       const T* in_values = reinterpret_cast<const T*>(arr_->values);
       for (int i = 0; i < arr_->length; ++i) {
-        out_values[i] = util::bit_not_set(arr_->nulls, i) ? NAN : in_values[i];
+        out_values[i] = util::bit_not_set(arr_->nulls, i) ? (double) NAN : in_values[i];
       }
     } else {
       out_ = PyArray_SimpleNew(1, dims, feather_traits<TYPE>::npy_type);

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -266,6 +266,12 @@ class TestFeatherReader(unittest.TestCase):
 
         self._check_pandas_roundtrip(df)
 
+    def test_timestamp_with_nulls(self):
+        df = pd.DataFrame({'test': [pd.datetime(2016,1,1),None,pd.datetime(2016,1,3)]})
+        df['with_tz'] = df.test.dt.tz_localize('utc')
+
+        self._check_pandas_roundtrip(df, null_counts=[1,1])
+
     def test_non_string_columns(self):
         df = pd.DataFrame({0: [1, 2, 3, 4],
                            1: [True, False, True, False]})


### PR DESCRIPTION
Deals with #230 and depends on #242.

* Writing missing values was fixed as in #242 updating the mask before writing to disk.
* Reading is still bogus but largely mitigated with that PR. Integer array with missing are imprecisely read as they are converted to floating point numbers. They used to be converted to 32-bit floating point number before been converted to 64-bit float. That costly intermediate conversion is removed in that PR.

I have a test that fails because of the 64-bit float conversion. This test is not part of the PR, just here for reference (extracted from test_reader.py).

```python
    def test_out_of_float64_timestamp_with_nulls(self):
        df = pd.DataFrame({'test': pd.DatetimeIndex([1451606400000000001,None,14516064000030405])})
        df['with_tz'] = df.test.dt.tz_localize('utc')

        self._check_pandas_roundtrip(df, null_counts=[1,1])
```



 