### PR TITLE
[C++] Fix issue when overwriting feather files

### DIFF
--- a/R/tests/testthat/test-overwrite.R
+++ b/R/tests/testthat/test-overwrite.R
@@ -1,0 +1,15 @@
+context("overwrite")
+
+test_that("can read new data", {
+  path <- tempfile()
+
+  x <- 1:100
+  write_feather(dplyr::data_frame(x = x), path)
+  on.exit(file.remove(path))
+  res <- read_feather(path)
+
+  y <- x[1:(length(x)/2)]
+  write_feather(dplyr::data_frame(y = y), path)
+  resy <- read_feather(path)
+  expect_identical(resy$y, y)
+})

--- a/cpp/src/feather/io.cc
+++ b/cpp/src/feather/io.cc
@@ -227,12 +227,12 @@ static inline Status FileOpenWriteable(const std::string& filename, int* fd) {
   memcpy(wpath.data(), filename.data(), filename.size());
   memcpy(wpath.data() + nwchars, L"\0", sizeof(wchar_t));
 
-  errno_actual = _wsopen_s(fd, wpath.data(), _O_WRONLY | _O_CREAT | _O_BINARY,
+  errno_actual = _wsopen_s(fd, wpath.data(), _O_WRONLY | _O_CREAT | _O_BINARY | _O_TRUNC,
       _SH_DENYNO, _S_IWRITE);
   ret = *fd;
 
 #else
-  ret = *fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_BINARY,
+  ret = *fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_BINARY | O_TRUNC,
       FEATHER_WRITE_SHMODE);
 #endif
   return CheckOpenResult(ret, errno_actual, filename.c_str(),

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -321,6 +321,18 @@ class TestFeatherReader(unittest.TestCase):
         expected = pd.DataFrame({c:data[c] for c in columns})
         self._check_pandas_roundtrip(df, expected, columns=columns)
 
+    def test_overwritten_file(self):
+        path = random_path()
+
+        num_values = 100
+        np.random.seed(0)
+
+        values = np.random.randint(0, 10, size=num_values)
+        feather.write_dataframe(pd.DataFrame({'ints':values}), path)
+
+        df = pd.DataFrame({'ints':values[0:num_values//2]})
+        self._check_pandas_roundtrip(df, path=path)
+
     def test_sparse_dataframe(self):
         # GH #221
         data = {'A': [0,1,2],


### PR DESCRIPTION
Fixes #249.

* Added R and Python tests and
* Added Truncate flag in the open call.

It may also impact #232 (as per the latest comment there).