### PR TITLE
[Python] Datetime and Categorical handling improvement

### DIFF
--- a/python/feather/ext.pyx
+++ b/python/feather/ext.pyx
@@ -260,8 +260,9 @@ cdef class FeatherReader:
 cdef category_to_pandas(CColumn* col):
     cdef CategoryColumn* cat = <CategoryColumn*>(col)
 
-    values = primitive_to_pandas(cat.values())
-    values[np.isnan(values)] = -1
+    values = raw_primitive_to_pandas(cat.values())
+    mask = primitive_mask(cat.values())
+    values[np.invert(mask)] = -1
     levels = primitive_to_pandas(cat.levels())
 
     return pd.Categorical(values, categories=levels,

--- a/python/feather/interop.h
+++ b/python/feather/interop.h
@@ -668,7 +668,7 @@ class FeatherDeserializer {
   PyObject* out_;
 };
 
-PyObject* primitive_mask(const PrimitiveArray& arr) {
+PyObject* get_null_mask(const PrimitiveArray& arr) {
   npy_intp dims[1] = {static_cast<npy_intp>(arr.length)};
   PyObject* out = PyArray_SimpleNew(1, dims, NPY_BOOL);
   if (out == NULL) return out;
@@ -676,11 +676,11 @@ PyObject* primitive_mask(const PrimitiveArray& arr) {
   uint8_t* out_values = reinterpret_cast<uint8_t*>(PyArray_DATA(out));
   if (arr.null_count > 0) {
     for (int64_t i = 0; i < arr.length; ++i) {
-      out_values[i] = util::get_bit(arr.nulls, i) ? 1 : 0;
+      out_values[i] = util::bit_not_set(arr.nulls, i);
     }
   } else {
     for (int64_t i = 0; i < arr.length; ++i) {
-      out_values[i] = 1;
+      out_values[i] = 0;
     }
   }
   return out;

--- a/python/feather/interop.h
+++ b/python/feather/interop.h
@@ -701,7 +701,14 @@ PyObject* primitive_mask(const PrimitiveArray& arr) {
 
 PyObject* raw_primitive_to_pandas(const PrimitiveArray& arr) {
   switch(arr.type) {
+    FROM_RAW_FEATHER_CASE(INT8);
+    FROM_RAW_FEATHER_CASE(INT16);
+    FROM_RAW_FEATHER_CASE(INT32);
     FROM_RAW_FEATHER_CASE(INT64);
+    FROM_RAW_FEATHER_CASE(UINT8);
+    FROM_RAW_FEATHER_CASE(UINT16);
+    FROM_RAW_FEATHER_CASE(UINT32);
+    FROM_RAW_FEATHER_CASE(UINT64);
     default:
       break;
   }

--- a/python/feather/tests/test_reader.py
+++ b/python/feather/tests/test_reader.py
@@ -299,6 +299,12 @@ class TestFeatherReader(unittest.TestCase):
 
         self._check_pandas_roundtrip(df, null_counts=[1,1])
 
+    def test_out_of_float64_timestamp_with_nulls(self):
+        df = pd.DataFrame({'test': pd.DatetimeIndex([1451606400000000001,None,14516064000030405])})
+        df['with_tz'] = df.test.dt.tz_localize('utc')
+
+        self._check_pandas_roundtrip(df, null_counts=[1,1])
+
     def test_non_string_columns(self):
         df = pd.DataFrame({0: [1, 2, 3, 4],
                            1: [True, False, True, False]})


### PR DESCRIPTION
Depends on #247.

* Allow null mask retrieval in Python
* Prevent int to float conversion when nulls are present (particularly relevant for high precision Datetimes - many significant figures).
* Prevent float array generation when nulls are present in categorical