### PR TITLE
[C++] fixes for gcc-4.4

### DIFF
--- a/cpp/src/feather/common.h
+++ b/cpp/src/feather/common.h
@@ -21,8 +21,8 @@ namespace feather {
 
 static constexpr const char* FEATHER_MAGIC_BYTES = "FEA1";
 
-static constexpr int kFeatherDefaultAlignment = 8;
-static constexpr int kFeatherVersion = 2;
+static constexpr const int kFeatherDefaultAlignment = 8;
+static constexpr const int kFeatherVersion = 2;
 
 static inline int64_t PaddedLength(int64_t nbytes) {
   static const int64_t alignment = kFeatherDefaultAlignment;

--- a/cpp/src/feather/status.h
+++ b/cpp/src/feather/status.h
@@ -33,7 +33,7 @@ enum class StatusCode: char {
   Invalid = 3,
   IOError = 4,
 
-  NotImplemented = 10,
+  NotImplemented = 10
 };
 
 class Status {

--- a/cpp/src/feather/types.h
+++ b/cpp/src/feather/types.h
@@ -47,7 +47,7 @@ struct PrimitiveType {
 
     UTF8 = 11,
 
-    BINARY = 12,
+    BINARY = 12
   };
 };
 


### PR DESCRIPTION
This PR resolves some compilation errors with `gcc-4.4`.

We're hoping to take this patch and re-submit to CRAN so that R users on RHEL5 can install `feather` more easily -- @wesm, would that be alright?