### PR TITLE
[CI] attempt to build R with gcc-4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,11 @@ matrix:
   - os: linux
     language: r
     compiler: gcc
+    addons:
+      apt:
+        packages:
+        - gcc-4.4
+        - g++-4.4
     r_binary_packages:
       - BH
       - crayon
@@ -57,6 +62,11 @@ matrix:
       - Rcpp
       - testthat
     before_install:
+    - mkdir -p ~/.R
+    - echo "CC = gcc-4.4 -std=gnu99"    >> ~/.R/Makevars
+    - echo "CXX = g++-4.4"              >> ~/.R/Makevars
+    - echo "CXX1X = g++-4.4 -std=c++0x" >> ~/.R/Makevars
+    - echo "CXX1XSTD = -std=c++0x"      >> ~/.R/Makevars
     - cd R
     after_success:
     - Rscript -e 'install.packages("covr"); covr::codecov()'


### PR DESCRIPTION
This PR tweaks the Travis build script, to attempt to build the R bits with `gcc-4.4`.

Note that I expect the R run to fail with this PR (https://github.com/wesm/feather/pull/254 provides the associated necessary fixes)