### PR TITLE
Check bounds on offsets

### DIFF
--- a/R/src/feather-types.cpp
+++ b/R/src/feather-types.cpp
@@ -164,7 +164,8 @@ SEXP toSEXP(const PrimitiveArray* val, const ArrayMetadata& meta) {
     int64_t total_bytes = meta.total_bytes;
     for (int i = 0; i < n; ++i) {
       int32_t offset1 = val->offsets[i], offset2 = val->offsets[i + 1];
-      if(offset1 > total_bytes || offset2 > total_bytes) {
+      if(offset1 < 0 || offset1 > total_bytes ||
+         offset2 < 0 || offset2 > total_bytes) {
         stop("Corrupt feather file: offsets out of bounds");
       }
       int32_t n = offset2 - offset1;

--- a/R/src/feather-types.cpp
+++ b/R/src/feather-types.cpp
@@ -148,9 +148,9 @@ SEXP toSEXP(const PrimitiveArray* val, const ArrayMetadata& meta) {
 
   case PrimitiveType::UTF8: {
     auto asChar = reinterpret_cast<const char*>(val->values);
-    auto total_bytes = meta.total_bytes;
+    int64_t total_bytes = meta.total_bytes;
     for (int i = 0; i < n; ++i) {
-      uint32_t offset1 = val->offsets[i], offset2 = val->offsets[i + 1];
+      int32_t offset1 = val->offsets[i], offset2 = val->offsets[i + 1];
       if(offset1 > total_bytes || offset2 > total_bytes) {
         stop("Corrupt feather file: offsets out of bounds");
       }
@@ -161,9 +161,9 @@ SEXP toSEXP(const PrimitiveArray* val, const ArrayMetadata& meta) {
   }
   case PrimitiveType::BINARY: {
     auto asChar = reinterpret_cast<const char*>(val->values);
-    auto total_bytes = meta.total_bytes;
+    int64_t total_bytes = meta.total_bytes;
     for (int i = 0; i < n; ++i) {
-      uint32_t offset1 = val->offsets[i], offset2 = val->offsets[i + 1];
+      int32_t offset1 = val->offsets[i], offset2 = val->offsets[i + 1];
       if(offset1 > total_bytes || offset2 > total_bytes) {
         stop("Corrupt feather file: offsets out of bounds");
       }

--- a/doc/FORMAT.md
+++ b/doc/FORMAT.md
@@ -57,6 +57,9 @@ We use the [Apache Arrow][3] encoding for storing variable-length values
 <null bitmask, optional> <int32_t* value offsets> <uint8_t* value data>
 ```
 
+libfeather does not perform any boundary checking on the offsets; libfeather
+clients are responsible for checking that the offsets are legal.
+
 ## Dictionary encoding
 
 Dictionary-encoded data is stored in the following layout.


### PR DESCRIPTION
Corrupted files may have invalid offsets that can result in
out-of-bounds memory access; cf. #266.

I haven't checked to see whether a symmetric change is necessary in the other language bindings; I wanted to get feedback on this approach first. Does this seem reasonable?