### PR TITLE
Add compatibility.h to cpp install

### DIFF
--- a/cpp/src/feather/CMakeLists.txt
+++ b/cpp/src/feather/CMakeLists.txt
@@ -112,6 +112,7 @@ install(FILES
   api.h
   buffer.h
   common.h
+  compatibility.h
   feather-c.h
   io.h
   metadata.h


### PR DESCRIPTION
compatibility.h is not installed by the cmake infrastructure but seems to be needed when including feather headers from C++.  This adds it.