### PR TITLE
[Python] More informative error message on unsupported type

### DIFF
--- a/python/feather/interop.h
+++ b/python/feather/interop.h
@@ -449,7 +449,9 @@ Status pandas_masked_to_primitive(PyObject* ao, PyObject* mo,
     TO_FEATHER_CASE(OBJECT);
     default:
       std::stringstream ss;
-      ss << "unsupported type " << type_num
+      ss << "Unsupported data type (NPY_TYPES enum value: " << type_num << "). "
+         << "Please refer to the Feather webpage for a list of supported "
+         << "column types."
          << std::endl;
       return Status::Invalid(ss.str());
   }


### PR DESCRIPTION
Issue: #270, attempting to save a data frame where a column has an unsupported data type gives the error:

```python
import numpy as np
import pandas as pd
import feather

df = pd.DataFrame({'nope': np.array([2.0, 3.5], dtype=np.float16)})
feather.write_dataframe(df, 'test.feather')
```
`FeatherError: Invalid: unsupported type 23 `


A more user friendly message could be: 

`FeatherError: Invalid: Unsupported data type (NPY_TYPES enum value: 23). Please refer to the Feather webpage for a list of supported column types.`