### PR TITLE
offset overflow at large (>2.4GB) string or binary columns

### DIFF
--- a/R/tests/testthat/test-roundtrip-vector.R
+++ b/R/tests/testthat/test-roundtrip-vector.R
@@ -119,3 +119,17 @@ test_that("doesn't lose undue precision", {
 
   expect_identical(x1, x2)
 })
+
+
+# Large data --------------------------------------------------------------
+
+test_that("withstands large (>2GB) columns", {
+  if (Sys.info()[['sysname']] != 'Windows' && 
+      Sys.info()[['machine']] == 'x86_64') {
+
+    x1 <- rep("23886fac-4311-41e3-83d2-c9c3e7556af3", 60*1e6) # 2.5GB
+    x2 <- roundtrip_vector(x1)
+
+    expect_identical(x1, x2)
+  }
+})

--- a/R/tests/testthat/test-roundtrip-vector.R
+++ b/R/tests/testthat/test-roundtrip-vector.R
@@ -120,16 +120,3 @@ test_that("doesn't lose undue precision", {
   expect_identical(x1, x2)
 })
 
-
-# Large data --------------------------------------------------------------
-
-test_that("withstands large (>2GB) columns", {
-  if (Sys.info()[['sysname']] != 'Windows' && 
-      Sys.info()[['machine']] == 'x86_64') {
-
-    x1 <- rep("23886fac-4311-41e3-83d2-c9c3e7556af3", 60*1e6) # 2.5GB
-    x2 <- roundtrip_vector(x1)
-
-    expect_identical(x1, x2)
-  }
-})

--- a/cpp/src/feather/io.cc
+++ b/cpp/src/feather/io.cc
@@ -289,8 +289,8 @@ static inline Status FileWrite(int fd, const uint8_t* buffer, int64_t nbytes) {
   }
   ret = _write(fd, buffer, static_cast<unsigned int>(nbytes));
 #else
-  // (skirpichenko): even on x64 systems `write` does not allow to write more than 2GB at once
-  // so lets split data into blocks and write sequentially
+  // (skirpichenko): even on x64 systems `write` does not allow to write more than
+  // 2GB at once, so lets split data into blocks and write sequentially
   int64_t offset = 0;
   do {
     ret = write(fd, buffer + offset, std::min(nbytes - offset, int64_t(1 << 30)));

--- a/cpp/src/feather/io.cc
+++ b/cpp/src/feather/io.cc
@@ -289,7 +289,13 @@ static inline Status FileWrite(int fd, const uint8_t* buffer, int64_t nbytes) {
   }
   ret = _write(fd, buffer, static_cast<unsigned int>(nbytes));
 #else
-  ret = write(fd, buffer, nbytes);
+  // (skirpichenko): even on x64 systems `write` does not allow to write more than 2GB at once
+  // so lets split data into blocks and write sequentially
+  int64_t offset = 0;
+  do {
+    ret = write(fd, buffer + offset, std::min(nbytes - offset, int64_t(1 << 30)));
+    offset += ret;
+  } while (ret != -1 && offset < nbytes);
 #endif
 
   if (ret == -1) {

--- a/cpp/src/feather/types.cc
+++ b/cpp/src/feather/types.cc
@@ -51,7 +51,11 @@ bool PrimitiveArray::Equals(const PrimitiveArray& other) const {
             (this->length + 1) * sizeof(int32_t)) != 0) {
       return false;
     }
-    size_t total_bytes = this->offsets[this->length] * ByteSize(this->type);
+    // (skirpichenko): sum up total_bytes instead of using last offset
+    size_t total_bytes = 0;
+    for (int i = 0; i < this->length; ++i) {
+      total_bytes += (this->offsets[i + 1] - this->offsets[i]) * ByteSize(this->type);
+    }
     if (memcmp(this->values, other.values, total_bytes) != 0) {
       return false;
     }

--- a/cpp/src/feather/writer.cc
+++ b/cpp/src/feather/writer.cc
@@ -108,12 +108,15 @@ Status TableWriter::AppendPrimitive(const PrimitiveArray& values,
   }
 
   size_t value_byte_size = ByteSize(values.type);
-  size_t values_bytes;
+  size_t values_bytes = 0;
 
   if (IsVariableLength(values.type)) {
     size_t offset_bytes = sizeof(int32_t) * (values.length + 1);
 
-    values_bytes = values.offsets[values.length] * value_byte_size;
+    // (skirpichenk0): sum up values_bytes instead of using last offset
+    for (int i = 0; i < values.length; ++i) {
+      values_bytes += (values.offsets[i+1] - values.offsets[i]) * value_byte_size;
+    }
 
     // Write the variable-length offsets
     RETURN_NOT_OK(stream_->WritePadded(reinterpret_cast<const uint8_t*>(values.offsets),


### PR DESCRIPTION
This PR closes the issue #232.

`Feather` saves string and binary columns as a flat buffer preposed by an array of offsets to the beginning and ending point of each field. The types of offsets are `int32_t` (32-bit signed integer). This leads to overflow when column size is bigger than 2.4GB and makes impossible to work with large data tables. The problem can be fixed without changing offset type and binary file format. The difference between the ending and beginning points still gives correct field length even with overflowed offsets. Thus the correct location of each field can be reconstructed summing up the lengths of all previous fields.