### PR TITLE
[Format] Add a note about required alignment

### DIFF
--- a/doc/FORMAT.md
+++ b/doc/FORMAT.md
@@ -16,6 +16,8 @@ Here is the general structure of the file:
 There is a stream of arrays laid out end-to-end, with the metadata appended on
 completion at the end of the file.
 
+Array and metadata starts must be aligned on 8-byte boundaries.
+
 For the arrays themselves, the memory layout is type dependent.
 
 1. Primitive arrays


### PR DESCRIPTION
8-byte alignment appears to be required by the C++ (and thus the Python and R) implementation.  I'm not sure if that's intended or a bug, but it makes sense to require given the high-performance focus of Feather and the performance impact of unaligned memory access.