### PR TITLE
Coerce dates to double when creating r objects

### DIFF
--- a/R/src/feather-types.cpp
+++ b/R/src/feather-types.cpp
@@ -266,7 +266,8 @@ SEXP toSEXP(const ColumnPtr& x) {
     return out;
   }
   case feather::ColumnType::DATE: {
-    IntegerVector out = toSEXP(val);
+    // Coerce dates to double for creating R column 
+    DoubleVector out = Rf_coerceVector(toSEXP(val), REALSXP);
     out.attr("class") = "Date";
     return out;
   }

--- a/R/tests/testthat/test-roundtrip-vector.R
+++ b/R/tests/testthat/test-roundtrip-vector.R
@@ -74,7 +74,6 @@ test_that("preserves NA in factor and levels", {
 
 test_that("preserves dates", {
   x <- as.Date("2010-01-01") + c(0L, 365L, NA)
-  mode(x) <- "integer"
   expect_identical(roundtrip_vector(x), x)
 })
 


### PR DESCRIPTION
This fixes #313, but wouldn't it be smarter to use edited versions of `toRColType()` and `toSEXPTYPE()`? I started to implement a `GetDate()` (as for times and timestamps) in `R/src/feather/reader.cc` and to edit `feather-types.cpp` and got confused in the type conversion process.

I also changed the roundtrip test for dates, which converted the date to int before roundtripping.