### PR TITLE
Add cstdio to status.h includes

### DIFF
--- a/cpp/src/feather/status.h
+++ b/cpp/src/feather/status.h
@@ -15,6 +15,7 @@
 #ifndef FEATHER_STATUS_H_
 #define FEATHER_STATUS_H_
 
+#include <cstdio>
 #include <cstdint>
 #include <cstring>
 #include <string>


### PR DESCRIPTION
snprintf() is called in status.cc and belongs to cstdio, which should then be included

This should fix #316, but this code is deprecated, efforts should be made to implement R bindings within Arrow.