### PR TITLE
[R] New test case for checking round trip of integer64 values

### DIFF
--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -22,6 +22,7 @@ Imports:
     hms
 Suggests:
     testthat,
-    dplyr
+    dplyr,
+    bit64
 SystemRequirements: little-endian platform
 RoxygenNote: 5.0.1

--- a/R/src/feather-write.cpp
+++ b/R/src/feather-write.cpp
@@ -359,6 +359,9 @@ Status addColumn(std::unique_ptr<TableWriter>& table,
   } else if (Rf_inherits(x, "POSIXlt")) {
     stop("Can not write POSIXlt (%s). Convert to POSIXct first.", name);
     return Status::NotImplemented("");
+  } else if (Rf_inherits(x, "integer64")) {
+    stop("Can not write integer64 (%s). Not yet implemented :(", name);
+    return Status::NotImplemented("");
   } else {
     return addPrimitiveColumn(table, name, x);
   }

--- a/R/tests/testthat.R
+++ b/R/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
 library(feather)
+library(bit64)
 
 test_check("feather")

--- a/R/tests/testthat/test-roundtrip-vector.R
+++ b/R/tests/testthat/test-roundtrip-vector.R
@@ -15,7 +15,14 @@ test_that("preserves logical vector of length 0", {
 # Integer ----------------------------------------------------------------
 
 test_that("preserves integer values", {
-  x <- 1:10
+  x <- c(1:10, NA_integer_, 12L)
+  expect_identical(roundtrip_vector(x), x)
+})
+
+# Integer64 ---------------------------------------------------------------
+
+test_that("preserves integer64 values", {
+  x <- c(as.integer64(1:10), NA_integer64_, 12L)
   expect_identical(roundtrip_vector(x), x)
 })
 


### PR DESCRIPTION
This pull request adds a new test case that checks whether `integer64` values (S3 class of package `bit64`) can be written and correctly read again by feather.
Currently this test fails. See also issue #276 