### PR TITLE
Fix for failing test for UTF-8 encoded filenames on Windows with R 3.5

### DIFF
--- a/R/R/class.R
+++ b/R/R/class.R
@@ -7,7 +7,7 @@
 #' @return An object of class \code{feather}
 #' @export
 feather <- function(path) {
-  path <- enc2native(path)
+  path <- enc2native(normalizePath(path, mustWork = TRUE))
 
   openFeather(path)
 }

--- a/R/R/class.R
+++ b/R/R/class.R
@@ -7,7 +7,7 @@
 #' @return An object of class \code{feather}
 #' @export
 feather <- function(path) {
-  path <- normalizePath(path, mustWork = TRUE)
+  path <- enc2native(path)
 
   openFeather(path)
 }


### PR DESCRIPTION
Adapts the same logic that fixed a similar problem in [readxl](https://github.com/tidyverse/readxl/commit/b10a1a80fba57e1e7e515b78f64acf62fd75843a) because of the change in behavior of `normalizePaths()` in R 3.5.