### PR TITLE
[R] Changed Rscript to run in --vanilla. fixes #310

### DIFF
--- a/R/configure
+++ b/R/configure
@@ -1,5 +1,5 @@
 # Check for little-endian system
-R_ENDIAN=`${R_HOME}/bin/Rscript -e 'cat(.Platform$endian)'`
+R_ENDIAN=`${R_HOME}/bin/Rscript --vanilla -e 'cat(.Platform$endian)'`
 # Trim off any warning messages that Rscript appends in front of the platform endianness
 R_ENDIAN=`expr "$R_ENDIAN" : '.*\(little\)$'`
 if [ "$R_ENDIAN" = "little" ]; then


### PR DESCRIPTION
Any custom `~/.Rprofile` file that prints messages will break the current endian detection.

Changed to run in `--vanilla` which implies `--no-site-file`, `--no-init-file`, `--no-environ` and `--no-restore`.

Example of behaviour with my custom `~/.Rprofile`

```r
.First <- function() {
    cat("\nWelcome at", date(), "\n")
}

.Last <- function() {
    cat("\nGoodbye at", date(), "\n")
}
```

```bash
> Rscript --no-site-file -e 'cat(.Platform$endian)'

Welcome at Wed Nov 14 14:40:31 2018
little
Goodbye at Wed Nov 14 14:40:31 2018
```

```bash
> Rscript --no-site-file --vanilla -e 'cat(.Platform$endian)'
little
```

