### PR TITLE
Specify long_description_content_type for pypi rendering, fixes #369

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -71,6 +71,7 @@ setup(
     install_requires=['pyarrow>=0.4.0'],
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
+    long_description_content_type='text/markdown',
     license='Apache License, Version 2.0',
     classifiers=CLASSIFIERS,
     author="Wes McKinney",


### PR DESCRIPTION
See https://packaging.python.org/guides/making-a-pypi-friendly-readme/#including-your-readme-in-your-package-s-metadata