### PR TITLE
feather_metadata: "~/" error

### DIFF
--- a/R/R/feather.R
+++ b/R/R/feather.R
@@ -43,6 +43,7 @@ write_feather <- function(x, path) {
 #' @return A list with class "feather_metadata".
 #' @export
 feather_metadata <- function(path) {
+  path <- path.expand(path)
   metadataFeather(path)
 }
 


### PR DESCRIPTION
In `feather_metadata()`, to avoid the error when using "~" in the path:
 - Added `path <- path.expand(path)`