### PR TITLE
[R] Changes for feather v0.3.3

### DIFF
--- a/R/.Rbuildignore
+++ b/R/.Rbuildignore
@@ -1,6 +1,7 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^src/feather/.*\.o$
+^src/feather/Makefile$
 ^src/.*\.a$
 ^cran-comments\.md$
 ^configure.win$

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: feather
 Title: R Bindings to the Feather 'API'
-Version: 0.3.2.9000
+Version: 0.3.3
 Authors@R: c(
     person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut", "cre")),
     person("RStudio", role = "cph"),

--- a/R/DESCRIPTION
+++ b/R/DESCRIPTION
@@ -21,7 +21,6 @@ Imports:
     tibble,
     hms
 Suggests:
-    testthat,
-    dplyr
+    testthat
 SystemRequirements: little-endian platform
 RoxygenNote: 6.1.1

--- a/R/NEWS.md
+++ b/R/NEWS.md
@@ -1,4 +1,8 @@
-# feather (development version)
+# feather 0.3.3
+
+* `feather_metadata()` now handles paths with `~` in them.
+
+* Fix warnings on CRAN due to (unused) GNU Makefiles.
 
 # feather 0.3.2
 

--- a/R/NEWS.md
+++ b/R/NEWS.md
@@ -4,6 +4,8 @@
 
 * Fix warnings on CRAN due to (unused) GNU Makefiles.
 
+* Use `tibble::tibble()` in place of the deprecated `dplyr::data_frame()`.
+
 # feather 0.3.2
 
 * Fixes for PROTECT error found by rchk.

--- a/R/R/feather.R
+++ b/R/R/feather.R
@@ -43,6 +43,7 @@ write_feather <- function(x, path) {
 #' @return A list with class "feather_metadata".
 #' @export
 feather_metadata <- function(path) {
+  path <- path.expand(path)
   metadataFeather(path)
 }
 

--- a/R/tests/testthat/helper-roundtrip.R
+++ b/R/tests/testthat/helper-roundtrip.R
@@ -1,5 +1,5 @@
 roundtrip_vector <- function(x) {
-  df <- dplyr::data_frame(x = x)
+  df <- tibble::tibble(x = x)
   roundtrip(df)$x
 }
 

--- a/R/tests/testthat/test-overwrite.R
+++ b/R/tests/testthat/test-overwrite.R
@@ -4,12 +4,12 @@ test_that("can read new data", {
   path <- tempfile()
 
   x <- 1:100
-  write_feather(dplyr::data_frame(x = x), path)
+  write_feather(tibble::tibble(x = x), path)
   on.exit(file.remove(path))
   res <- read_feather(path)
 
   y <- x[1:(length(x)/2)]
-  write_feather(dplyr::data_frame(y = y), path)
+  write_feather(tibble::tibble(y = y), path)
   resy <- read_feather(path)
   expect_identical(resy$y, y)
 })


### PR DESCRIPTION
Minor changes needed for the release, the main impetus was to avoid the current WARNINGs on CRAN due to the use of GNU Make idioms in the (unused by the R package) feather Makefile. This also includes the small fix from #371. 

cc @hadley 

Fixes #373 